### PR TITLE
Page.href -> page.url

### DIFF
--- a/packages/meta-page/src/index.ts
+++ b/packages/meta-page/src/index.ts
@@ -2,7 +2,7 @@ import type { Meta } from '@grafana/javascript-agent-core';
 
 const pageMeta: Meta = () => ({
   page: () => ({
-    href: location.href,
+    url: location.href,
   }),
 });
 


### PR DESCRIPTION
Backend expcects `page.url` not `page.href`