### PR TITLE
Feature: agent.api.pushError method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Updated build: packages will be published with a build targeting es5 with common-js modules,
 and a build targeting es6 with ecmascript modules.
+* `agent.api.pushError` method to push `Error` objects directly
 
 ## 0.2.0 (2022-06-03)
 

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -26,6 +26,8 @@
     <button data-cy="btn-call-undefined" onclick="callUndefined()">Call undefined method</button>
     <button data-cy="btn-fetch-error" onclick="fetchError()">Fetch error</button>
     <button data-cy="btn-promise-reject" onclick="promiseReject()">Promise reject</button>
+    <button data-cy="btn-push-error" onclick="pushError()">Push an error</button>
+
     <hr />
 
     <h2>Tracing Instrumentation</h2>

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -281,4 +281,7 @@ agent.api.pushMeasurement({
     duration: 4000
   }
 });
+
+// push an Error
+agent.api.pushError(new Error('everything went horribly wrong'));
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,21 +56,20 @@ global.grafanaAgent.api.pushLog(/* ... */);
 
 The `api` property on the agent contains all the necessary methods to push new events.
 
-## Exceptions
+## Errors
 
-- `pushException` - is a method to push an error/exception to the agent. It accepts a mandatory `message` parameter
+- `pushError` - is a method to push an error/exception to the agent. It accepts a mandatory `message` parameter
   and an optional one where you can set:
 
-  - `span` - the span where the exception has occurred. Default value: `undefined`.
-  - `stackFrames` - an array of stack frames. Default value: `[]`.
-  - `type` - the type of exception. Default value: `error`.
+  - `stackFrames` - an array of stack frames. Defaults to parsing `error.stack` if present.
+  - `type` - the type of exception. Default value: `error.name` or `"error"`.
 
   ```ts
-  agent.api.pushException('This is an error');
+  agent.api.pushError(new Error('This is an error'));
 
-  agent.api.pushException('This is an unhandled exception', { type: 'unhandledException' });
+  agent.api.pushError(new Error('This is an unhandled exception'), { type: 'unhandledException' });
 
-  agent.api.pushException('This is an error with stack frames', {
+  agent.api.pushError(new Error('This is an error with stack frames'), {
     stackFrames: [
       {
         filename: 'file.js',
@@ -79,10 +78,6 @@ The `api` property on the agent contains all the necessary methods to push new e
         lineno: 80,
       },
     ],
-  });
-
-  agent.api.pushException('This is an error in a span', {
-    span: mySpan,
   });
   ```
 

--- a/packages/core/src/api/exceptions/index.ts
+++ b/packages/core/src/api/exceptions/index.ts
@@ -1,6 +1,6 @@
 export { defaultExceptionType } from './const';
 
-export { initializeExceptions } from './initialize';
+export { initializeExceptionsAPI } from './initialize';
 
 export type {
   ExceptionEvent,

--- a/packages/core/src/api/exceptions/index.ts
+++ b/packages/core/src/api/exceptions/index.ts
@@ -2,4 +2,11 @@ export { defaultExceptionType } from './const';
 
 export { initializeExceptions } from './initialize';
 
-export type { ExceptionEvent, ExceptionStackFrame, ExceptionsAPI, PushExceptionOptions } from './types';
+export type {
+  ExceptionEvent,
+  ExceptionStackFrame,
+  ExceptionsAPI,
+  PushExceptionOptions,
+  ExtendedError,
+  Stacktrace,
+} from './types';

--- a/packages/core/src/api/exceptions/index.ts
+++ b/packages/core/src/api/exceptions/index.ts
@@ -6,7 +6,7 @@ export type {
   ExceptionEvent,
   ExceptionStackFrame,
   ExceptionsAPI,
-  PushExceptionOptions,
+  PushErrorOptions,
   ExtendedError,
   Stacktrace,
 } from './types';

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -18,38 +18,38 @@ describe('api.exceptions', () => {
     return [api, transport];
   }
 
-  describe('pushException', () => {
-    const [api, transport] = createAPI();
-    const frames: ExceptionStackFrame[] = [
-      {
-        filename: 'foo.js',
-        function: 'FooFn',
-        colno: 4,
-        lineno: 23,
-      },
-      {
-        filename: 'bar.js',
-        function: 'BarFn',
-        colno: 6,
-        lineno: 52,
-      },
-    ];
-    api.pushException('test exception', {
-      stackFrames: frames,
-      type: 'TestError',
-    });
-    expect(transport.items).toHaveLength(1);
-    const payload = transport.items[0];
-    expect(payload?.payload).toBeTruthy();
-    expect(payload?.type).toEqual(TransportItemType.EXCEPTION);
-    const event = payload?.payload as ExceptionEvent;
-    expect(event.type).toEqual('TestError');
-    expect(event.value).toEqual('test exception');
-    expect(event.stacktrace).toEqual({ frames });
-  });
-
   describe('pushError', () => {
-    it('should report an exception', () => {
+    it('error with overrides', () => {
+      const [api, transport] = createAPI();
+      const frames: ExceptionStackFrame[] = [
+        {
+          filename: 'foo.js',
+          function: 'FooFn',
+          colno: 4,
+          lineno: 23,
+        },
+        {
+          filename: 'bar.js',
+          function: 'BarFn',
+          colno: 6,
+          lineno: 52,
+        },
+      ];
+      api.pushError(new Error('test exception'), {
+        stackFrames: frames,
+        type: 'TestError',
+      });
+      expect(transport.items).toHaveLength(1);
+      const payload = transport.items[0];
+      expect(payload?.payload).toBeTruthy();
+      expect(payload?.type).toEqual(TransportItemType.EXCEPTION);
+      const event = payload?.payload as ExceptionEvent;
+      expect(event.type).toEqual('TestError');
+      expect(event.value).toEqual('test exception');
+      expect(event.stacktrace).toEqual({ frames });
+    });
+
+    it('error without overrides', () => {
       const [api, transport] = createAPI();
 
       const err = new Error('test');

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -1,0 +1,74 @@
+import { initializeMetas } from '../../metas';
+import { initializeTransports, TransportItemType } from '../../transports';
+import { mockConfig, MockTransport } from '../../utils/tests';
+import { initializeTracesAPI } from '../traces';
+import { initializeExceptionsAPI } from './initialize';
+import type { ExceptionEvent, ExceptionsAPI, ExceptionStackFrame } from './types';
+
+describe('api.exceptions', () => {
+  function createAPI(): [ExceptionsAPI, MockTransport] {
+    const transport = new MockTransport();
+    const config = mockConfig({
+      transports: [transport],
+    });
+    const transports = initializeTransports(config);
+    const metas = initializeMetas(config);
+    const tracesAPI = initializeTracesAPI(transports, metas);
+    const api = initializeExceptionsAPI(config, transports, metas, tracesAPI);
+    return [api, transport];
+  }
+
+  describe('pushException', () => {
+    const [api, transport] = createAPI();
+    const frames: ExceptionStackFrame[] = [
+      {
+        filename: 'foo.js',
+        function: 'FooFn',
+        colno: 4,
+        lineno: 23,
+      },
+      {
+        filename: 'bar.js',
+        function: 'BarFn',
+        colno: 6,
+        lineno: 52,
+      },
+    ];
+    api.pushException('test exception', {
+      stackFrames: frames,
+      type: 'TestError',
+    });
+    expect(transport.items).toHaveLength(1);
+    const payload = transport.items[0];
+    expect(payload?.payload).toBeTruthy();
+    expect(payload?.type).toEqual(TransportItemType.EXCEPTION);
+    const event = payload?.payload as ExceptionEvent;
+    expect(event.type).toEqual('TestError');
+    expect(event.value).toEqual('test exception');
+    expect(event.stacktrace).toEqual({ frames });
+  });
+
+  describe('pushError', () => {
+    it('should report an exception', () => {
+      const [api, transport] = createAPI();
+
+      const err = new Error('test');
+      api.pushError(err);
+      expect(transport.items).toHaveLength(1);
+      const payload = transport.items[0];
+      expect(payload?.meta.app?.name).toEqual('test');
+      expect(payload?.payload).toBeTruthy();
+      expect(payload?.type).toEqual(TransportItemType.EXCEPTION);
+      const event = payload?.payload as ExceptionEvent;
+      expect(event.type).toEqual('Error');
+      expect(event.value).toEqual('test');
+      expect(event.timestamp).toBeTruthy();
+      const stacktrace = event.stacktrace;
+      expect(stacktrace).toBeTruthy();
+      expect(stacktrace?.frames.length).toBeGreaterThan(3);
+      expect(stacktrace?.frames[0]?.filename).toEqual('Error: test');
+    });
+  });
+});
+
+export {};

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -7,7 +7,7 @@ import type { TracesAPI } from '../traces';
 import { defaultExceptionType } from './const';
 import type { ExceptionEvent, ExceptionsAPI, PushExceptionOptions } from './types';
 
-export function initializeExceptions(
+export function initializeExceptionsAPI(
   config: Config,
   transports: Transports,
   metas: Metas,

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -26,12 +26,11 @@ export interface ExceptionEvent {
   trace?: TraceContext;
 }
 
-export interface PushExceptionOptions {
+export interface PushErrorOptions {
   stackFrames?: ExceptionStackFrame[];
   type?: string;
 }
 
 export interface ExceptionsAPI {
-  pushError: (error: Error) => void;
-  pushException: (value: string, options?: PushExceptionOptions) => void;
+  pushError: (value: Error, options?: PushErrorOptions) => void;
 }

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -7,15 +7,22 @@ export interface ExceptionStackFrame {
   colno?: number;
   lineno?: number;
 }
+export interface ExtendedError extends Error {
+  columnNumber?: number;
+  framesToPop?: number;
+  stacktrace?: Error['stack'];
+}
+
+export interface Stacktrace {
+  frames: ExceptionStackFrame[];
+}
 
 export interface ExceptionEvent {
   timestamp: string;
   type: string;
   value: string;
 
-  stacktrace?: {
-    frames: ExceptionStackFrame[];
-  };
+  stacktrace?: Stacktrace;
   trace?: TraceContext;
 }
 
@@ -25,5 +32,6 @@ export interface PushExceptionOptions {
 }
 
 export interface ExceptionsAPI {
+  pushError: (error: Error) => void;
   pushException: (value: string, options?: PushExceptionOptions) => void;
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -2,7 +2,7 @@ export { initializeAPI } from './initialize';
 export type { API, APIEvent } from './types';
 
 export { defaultExceptionType } from './exceptions';
-export type { ExceptionEvent, ExceptionStackFrame } from './exceptions';
+export type { ExceptionEvent, ExceptionStackFrame, Stacktrace, ExtendedError } from './exceptions';
 
 export { allLogLevels, defaultLogLevel, LogLevel } from './logs';
 export type { LogContext, LogEvent } from './logs';

--- a/packages/core/src/api/initialize.ts
+++ b/packages/core/src/api/initialize.ts
@@ -1,3 +1,4 @@
+import type { Config } from '../config';
 import type { Metas } from '../metas';
 import type { Transports } from '../transports';
 import { initializeExceptions } from './exceptions';
@@ -7,12 +8,12 @@ import { initializeMeta } from './meta/initialize';
 import { initializeTraces } from './traces';
 import type { API } from './types';
 
-export function initializeAPI(transports: Transports, metas: Metas): API {
+export function initializeAPI(config: Config, transports: Transports, metas: Metas): API {
   const tracesApi = initializeTraces(transports, metas);
 
   return {
     ...tracesApi,
-    ...initializeExceptions(transports, metas, tracesApi),
+    ...initializeExceptions(config, transports, metas, tracesApi),
     ...initializeMeta(transports, metas),
     ...initializeLogs(transports, metas, tracesApi),
     ...initializeMeasurements(transports, metas, tracesApi),

--- a/packages/core/src/api/initialize.ts
+++ b/packages/core/src/api/initialize.ts
@@ -1,21 +1,21 @@
 import type { Config } from '../config';
 import type { Metas } from '../metas';
 import type { Transports } from '../transports';
-import { initializeExceptions } from './exceptions';
-import { initializeLogs } from './logs';
-import { initializeMeasurements } from './measurements';
-import { initializeMeta } from './meta/initialize';
-import { initializeTraces } from './traces';
+import { initializeExceptionsAPI } from './exceptions';
+import { initializeLogsAPI } from './logs';
+import { initializeMeasurementsAPI } from './measurements';
+import { initializeMetaAPI } from './meta/initialize';
+import { initializeTracesAPI } from './traces';
 import type { API } from './types';
 
 export function initializeAPI(config: Config, transports: Transports, metas: Metas): API {
-  const tracesApi = initializeTraces(transports, metas);
+  const tracesApi = initializeTracesAPI(transports, metas);
 
   return {
     ...tracesApi,
-    ...initializeExceptions(config, transports, metas, tracesApi),
-    ...initializeMeta(transports, metas),
-    ...initializeLogs(transports, metas, tracesApi),
-    ...initializeMeasurements(transports, metas, tracesApi),
+    ...initializeExceptionsAPI(config, transports, metas, tracesApi),
+    ...initializeMetaAPI(transports, metas),
+    ...initializeLogsAPI(transports, metas, tracesApi),
+    ...initializeMeasurementsAPI(transports, metas, tracesApi),
   };
 }

--- a/packages/core/src/api/logs/index.ts
+++ b/packages/core/src/api/logs/index.ts
@@ -1,6 +1,6 @@
 export { allLogLevels, defaultLogLevel } from './const';
 
-export { initializeLogs } from './initialize';
+export { initializeLogsAPI } from './initialize';
 
 export { LogLevel } from './types';
 export type { LogContext, LogEvent, LogsAPI, PushLogOptions } from './types';

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -6,7 +6,7 @@ import type { TracesAPI } from '../traces';
 import { defaultLogLevel, originalConsoleMethods } from './const';
 import type { LogEvent, LogsAPI } from './types';
 
-export function initializeLogs(transports: Transports, metas: Metas, tracesApi: TracesAPI): LogsAPI {
+export function initializeLogsAPI(transports: Transports, metas: Metas, tracesApi: TracesAPI): LogsAPI {
   const pushLog: LogsAPI['pushLog'] = (args, { context, level } = {}) => {
     try {
       const item: TransportItem<LogEvent> = {

--- a/packages/core/src/api/measurements/index.ts
+++ b/packages/core/src/api/measurements/index.ts
@@ -1,3 +1,3 @@
-export { initializeMeasurements } from './initialize';
+export { initializeMeasurementsAPI } from './initialize';
 
 export type { MeasurementEvent, MeasurementsAPI, PushMeasurementOptions } from './types';

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -4,7 +4,7 @@ import type { Transports } from '../../transports';
 import type { TracesAPI } from '../traces';
 import type { MeasurementEvent, MeasurementsAPI } from './types';
 
-export function initializeMeasurements(transports: Transports, metas: Metas, tracesApi: TracesAPI): MeasurementsAPI {
+export function initializeMeasurementsAPI(transports: Transports, metas: Metas, tracesApi: TracesAPI): MeasurementsAPI {
   const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (payload) => {
     try {
       const item: TransportItem<MeasurementEvent> = {

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -2,7 +2,7 @@ import type { Meta, Metas, User } from '../../metas';
 import type { Transports } from '../../transports';
 import type { MetaAPI } from './types';
 
-export function initializeMeta(_: Transports, metas: Metas): MetaAPI {
+export function initializeMetaAPI(_: Transports, metas: Metas): MetaAPI {
   let meta: Meta = {};
 
   metas.add(() => meta);

--- a/packages/core/src/api/traces/index.ts
+++ b/packages/core/src/api/traces/index.ts
@@ -1,3 +1,3 @@
-export { initializeTraces } from './initialize';
+export { initializeTracesAPI } from './initialize';
 
 export type { TraceEvent, TracesAPI, TraceContext, ResourceSpan, InstrumentationLibrarySpan } from './types';

--- a/packages/core/src/api/traces/initialize.ts
+++ b/packages/core/src/api/traces/initialize.ts
@@ -4,7 +4,7 @@ import type { Metas } from '../../metas';
 import { TransportItem, TransportItemType, Transports } from '../../transports';
 import type { OTELApi, TraceContext, TraceEvent, TracesAPI } from './types';
 
-export function initializeTraces(_transports: Transports, _metas: Metas): TracesAPI {
+export function initializeTracesAPI(_transports: Transports, _metas: Metas): TracesAPI {
   let otel: OTELApi | undefined = undefined;
 
   const initOTEL = (trace: OTELTraceAPI, context: OTELContextAPI) => {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -10,11 +10,14 @@ export interface Config<P = APIEvent> {
   transports: Transport[];
   metas: MetaItem[];
   app: App;
+  parseStacktrace: StacktraceParser;
+
   session?: Session;
   user?: User;
   beforeSend?: BeforeSendHook<P>;
   ignoreErrors?: Patterns;
-  parseStacktrace?: (err: ExtendedError) => Stacktrace;
 }
+
+export type StacktraceParser = (err: ExtendedError) => Stacktrace;
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,4 +1,4 @@
-import type { APIEvent } from '../api';
+import type { APIEvent, ExtendedError, Stacktrace } from '../api';
 import type { Instrumentation } from '../instrumentations';
 import type { App, User, Session, MetaItem } from '../metas';
 import type { BeforeSendHook, Transport } from '../transports';
@@ -14,6 +14,7 @@ export interface Config<P = APIEvent> {
   user?: User;
   beforeSend?: BeforeSendHook<P>;
   ignoreErrors?: Patterns;
+  parseStacktrace?: (err: ExtendedError) => Stacktrace;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   TraceEvent,
   ResourceSpan,
   InstrumentationLibrarySpan,
+  Stacktrace,
 } from './api';
 
 export { initializeAgent } from './initialize';

--- a/packages/core/src/initialize.ts
+++ b/packages/core/src/initialize.ts
@@ -10,7 +10,7 @@ import { globalObject } from './utils';
 export function initializeAgent(config: Config): Agent {
   const metas = initializeMetas(config);
   const transports = initializeTransports(config);
-  const api = initializeAPI(transports, metas);
+  const api = initializeAPI(config, transports, metas);
 
   const agent = initializeGlobalAgent({
     config,

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -1,4 +1,5 @@
 import type { APIEvent, ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent } from '../api';
+import type { Patterns } from '../config';
 import type { Meta } from '../metas';
 
 export enum TransportItemType {
@@ -22,7 +23,7 @@ export interface Transport {
   send(item: TransportItem): void | Promise<void>;
 
   // returns URLs to be ignored by tracing, to not cause a feedback loop
-  getIgnoreUrls(): Array<string | RegExp>;
+  getIgnoreUrls(): Patterns;
 }
 export interface TransportBody {
   exceptions?: ExceptionEvent[];

--- a/packages/core/src/utils/tests.ts
+++ b/packages/core/src/utils/tests.ts
@@ -1,0 +1,51 @@
+import type { APIEvent, ExceptionStackFrame } from '../api';
+import type { Config, Patterns } from '../config';
+import type { StacktraceParser } from '../config/types';
+import type { Transport, TransportItem } from '../transports';
+
+export class MockTransport implements Transport {
+  items: Array<TransportItem<APIEvent>> = [];
+
+  constructor(private ignoreURLs: Patterns = []) {}
+
+  send(item: TransportItem<APIEvent>): void | Promise<void> {
+    this.items.push(item);
+  }
+
+  getIgnoreUrls(): Patterns {
+    return this.ignoreURLs;
+  }
+}
+
+export function mockConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    globalObjectKey: 'grafanaAgent',
+    instrumentations: [],
+    preventGlobalExposure: true,
+    transports: [],
+    metas: [],
+    app: {
+      name: 'test',
+      version: '1.0.0',
+    },
+    parseStacktrace: mockStacktraceParser,
+    ...overrides,
+  };
+}
+
+export const mockStacktraceParser: StacktraceParser = (err) => {
+  const frames: ExceptionStackFrame[] = [];
+  const stack = err.stack ?? err.stacktrace;
+  if (stack) {
+    stack.split('\n').forEach((line) => {
+      frames.push({
+        filename: line,
+        function: '',
+      });
+    });
+  }
+
+  return {
+    frames,
+  };
+};

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -41,6 +41,9 @@ agent.api.pushLog(['hello world']);
 
 // will be captured
 throw new Error('oh no');
+
+// push error manually
+agent.api.pushError(new Error('oh no'));
 ```
 
 With OTEL tracing and browser console capture:

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -10,7 +10,12 @@ import {
   Patterns,
 } from '@grafana/agent-core';
 
-import { ConsoleInstrumentation, ErrorsInstrumentation, WebVitalsInstrumentation } from './instrumentations';
+import {
+  ConsoleInstrumentation,
+  ErrorsInstrumentation,
+  parseStacktrace,
+  WebVitalsInstrumentation,
+} from './instrumentations';
 import { browserMeta, pageMeta } from './metas';
 import { FetchTransport } from './transports';
 
@@ -72,6 +77,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     session: browserConfig.session,
     user: browserConfig.user,
     ignoreErrors: browserConfig.ignoreErrors,
+    parseStacktrace,
   };
 
   return config;

--- a/packages/web/src/instrumentations/errors/index.ts
+++ b/packages/web/src/instrumentations/errors/index.ts
@@ -3,6 +3,8 @@ import { BaseInstrumentation, VERSION } from '@grafana/agent-core';
 import { registerOnerror } from './registerOnerror';
 import { registerOnunhandledrejection } from './registerOnunhandledrejection';
 
+export { parseStacktrace } from './stackFrames';
+
 export class ErrorsInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
   readonly name = '@grafana/agent-web:instrumentation-errors';

--- a/packages/web/src/instrumentations/errors/registerOnerror.ts
+++ b/packages/web/src/instrumentations/errors/registerOnerror.ts
@@ -30,7 +30,7 @@ export function registerOnerror(agent: Agent): void {
     }
 
     if (value) {
-      agent.api.pushException(value, { type, stackFrames });
+      agent.api.pushError(new Error(value), { type, stackFrames });
     }
   };
 }

--- a/packages/web/src/instrumentations/errors/registerOnunhandledrejection.ts
+++ b/packages/web/src/instrumentations/errors/registerOnunhandledrejection.ts
@@ -25,7 +25,7 @@ export function registerOnunhandledrejection(agent: Agent): void {
     }
 
     if (value) {
-      agent.api.pushException(value, { type });
+      agent.api.pushError(new Error(value), { type });
     }
   });
 }

--- a/packages/web/src/instrumentations/errors/stackFrames.ts
+++ b/packages/web/src/instrumentations/errors/stackFrames.ts
@@ -1,4 +1,4 @@
-import type { ExceptionStackFrame } from '@grafana/agent-core';
+import type { ExceptionStackFrame, Stacktrace } from '@grafana/agent-core';
 import { isNumber } from '@grafana/agent-core';
 
 import {
@@ -149,4 +149,10 @@ export function getStackFramesFromError(error: ExtendedError): ExceptionStackFra
   }
 
   return stackFrames;
+}
+
+export function parseStacktrace(error: ExtendedError): Stacktrace {
+  return {
+    frames: getStackFramesFromError(error),
+  };
 }


### PR DESCRIPTION
This pr adds a method to capture exceptions from `Error` objects:

```javascript
const err = new Error('bad thing happend');
grafanaAgent.api.pushError(err);
```

Notes:
Added `parseStacktrace` parameter to core config, so that web / node agents can supply own stacktrace parser

fixes #20

- [x] add tests