### PR TITLE
Docs: Fix typo doSoemthing -> doSomething

### DIFF
--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -174,7 +174,7 @@ const { trace, context } = agent.api.getOTEL();
 const tracer = trace.getTracer('default');
 const span = tracer.startSpan('click');
 context.with(trace.setSpan(context.active(), span), () => {
-  doSoemthing();
+  doSomething();
   span.end();
 })
 ```


### PR DESCRIPTION
This fixes a small typo in `docs/sources/tutorials/quick-start-browser.md`.

`doSoemthing()` -> `doSomething()`