### PR TITLE
Add agent.pause() and agent.unpause()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+
 * Added `agent.pause()` and `agent.unpause()` to be able to temproarily stop
 ingesting events.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+* Added `agent.pause()` and `agent.unpause()` to be able to temproarily stop
+ingesting events.
+
 ## 0.3.0 (2022-06-16)
 
 * Updated build: packages will be published with a build targeting es5 with common-js modules,

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -4,9 +4,9 @@ This document describes how to set up and use Grafana Javascript Agent. For more
 
 ## Before you begin
 
-* Set up a Grafana Agent instance. For more information , refer to [Grafana Agent set up documentation](https://grafana.com/docs/agent/latest/set-up/).
-* Configure your instance with `app-agent-receiver` integration to expose a http collection
-endpoint and run with the `integrations-next` flag enabled.
+- Set up a Grafana Agent instance. For more information , refer to [Grafana Agent set up documentation](https://grafana.com/docs/agent/latest/set-up/).
+- Configure your instance with `app-agent-receiver` integration to expose a http collection
+  endpoint and run with the `integrations-next` flag enabled.
 
 The following is an example of a basic Grafana Agent configuration that exposes a collector endpoint
 at [http://host:12345/collect](http://host:12345/collect) and forwards collected telemetry to Loki,
@@ -51,19 +51,19 @@ integrations:
   app_agent_receiver_configs:
     - autoscrape:
         enable: true
-        metrics_instance: "default"
-      api_key: "secret" # optional, if set, client will be required to provide it via x-api-key header
-      instance: "frontend"
-      logs_instance: "default"
-      traces_instance: "default"
+        metrics_instance: 'default'
+      api_key: 'secret' # optional, if set, client will be required to provide it via x-api-key header
+      instance: 'frontend'
+      logs_instance: 'default'
+      traces_instance: 'default'
       server:
         host: 0.0.0.0
         port: 12345
         cors_allowed_origins:
-          - "https://my-app.example.com"
+          - 'https://my-app.example.com'
       logs_labels: # labels to add to loki log record
         app: frontend # static value
-        kind:         # value will be taken from log items. exception, log, measurement, etc
+        kind: # value will be taken from log items. exception, log, measurement, etc
       logs_send_timeout: 5000
       sourcemaps:
         download: true # will download source file, extract source map location,
@@ -122,22 +122,30 @@ const agent = initializeAgent({
 You can also explicitly specify and customize transports and instrumentations.
 
 ```javascript
-import { LogLevel, ConsoleInstrumentation, initializeAgent, FetchTransport,
-ConsoleTransport, WebVitalsInstrumentation, ErrorsInstrumentation } from '@grafana/agent-web';
+import {
+  LogLevel,
+  ConsoleInstrumentation,
+  initializeAgent,
+  FetchTransport,
+  ConsoleTransport,
+  WebVitalsInstrumentation,
+  ErrorsInstrumentation,
+} from '@grafana/agent-web';
 
 const agent = initializeAgent({
   instrumentations: [
     new ErrorsInstrumentation(),
     new WebVitalsInstrumentation(),
     new ConsoleInstrumentation({
-      disabledLevels: [LogLevel.TRACE, LogLevel.ERROR] // console.log will be captured
-    })],
+      disabledLevels: [LogLevel.TRACE, LogLevel.ERROR], // console.log will be captured
+    }),
+  ],
   transports: [
     new FetchTransport({
       url: 'http://localhost:12345/collect',
       apiKey: 'secret',
     }),
-    new ConsoleTransport()
+    new ConsoleTransport(),
   ],
   app: {
     name: 'frontend',
@@ -176,7 +184,7 @@ const span = tracer.startSpan('click');
 context.with(trace.setSpan(context.active(), span), () => {
   doSoemthing();
   span.end();
-})
+});
 ```
 
 ### With custom Open Telemetry tracing configuration
@@ -215,10 +223,12 @@ const agent = initializeAgent({
 });
 
 // set up otel
-const resource = Resource.default().merge(new Resource({
-  [SemanticResourceAttributes.SERVICE_NAME]: NAME,
-  [SemanticResourceAttributes.SERVICE_VERSION]: VERSION
-}));
+const resource = Resource.default().merge(
+  new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: NAME,
+    [SemanticResourceAttributes.SERVICE_VERSION]: VERSION,
+  })
+);
 
 const provider = new WebTracerProvider({ resource });
 provider.addSpanProcessor(new BatchSpanProcessor(new GrafanaAgentTraceExporter({ agent })));
@@ -232,8 +242,8 @@ registerInstrumentations({
     new DocumentLoadInstrumentation(),
     new FetchInstrumentation({ ignoreUrls }),
     new XMLHttpRequestInstrumentation({ ignoreUrls }),
-    new UserInteractionInstrumentation()
-  ]
+    new UserInteractionInstrumentation(),
+  ],
 });
 
 // register otel with agent
@@ -284,4 +294,10 @@ agent.api.pushMeasurement({
 
 // push an Error
 agent.api.pushError(new Error('everything went horribly wrong'));
+
+// pause agent, preventing events from being sent
+agent.pause()
+
+// resume sending events
+agent.unpause()
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,18 +21,20 @@ initializeAgent({
 
 The agent requires a configuration parameter.
 
-| Property                | Description                                                                            | Type                | Optional | Default Value  |
-| ----------------------- | -------------------------------------------------------------------------------------- | ------------------- | -------- | -------------- |
-| `app`                   | Application metadata                                                                   | `App`               | Y        | `undefined`    |
-| `beforeSend`            | Hook invoked before pushing event to transport. Can be used to modify or filter events | `BeforeSendHook`    | Y        | `undefined`    |
-| `globalObjectKey`       | String that should be used when defining the agent on the global object                | `string`            | Y        | `grafanaAgent` |
-| `ignoreErrors`          | Error message patterns for errors that should be ignored                               | `Patterns`          | Y        | `[]`           |
-| `instrumentations`      | Array of instrumentations that should be ran                                           | `Instrumentation[]` | N        | `[]`           |
-| `metas`                 | Array of metas that should be logged                                                   | `MetaItem[]`        | Y        | `[]`           |
-| `preventGlobalExposure` | Flag for toggling the definition on the global object                                  | `boolean`           | Y        | `false`        |
-| `session`               | Session metadata                                                                       | `Session`           | Y        | `undefined`    |
-| `transports`            | Array of transports that should be used                                                | `Transport[]`       | Y        | `[]`           |
-| `user`                  | User metadata                                                                          | `User`              | Y        | `undefined`    |
+| Property                | Description                                                                            | Type                | Optional | Default Value |
+| ----------------------- | -------------------------------------------------------------------------------------- | ------------------- | -------- | ------------- |
+| `app`                   | Application metadata                                                                   | `App`               | N        | `undefined`   |
+| `beforeSend`            | Hook invoked before pushing event to transport. Can be used to modify or filter events | `BeforeSendHook`    | Y        | `undefined`   |
+| `globalObjectKey`       | String that should be used when defining the agent on the global object                | `string`            | N        |               |
+| `ignoreErrors`          | Error message patterns for errors that should be ignored                               | `Patterns`          | Y        | `[]`          |
+| `instrumentations`      | Array of instrumentations that should be ran                                           | `Instrumentation[]` | N        |               |
+| `metas`                 | Array of metas that should be logged                                                   | `MetaItem[]`        | N        |               |
+| `preventGlobalExposure` | Flag for toggling the definition on the global object                                  | `boolean`           | N        |               |
+| `session`               | Session metadata                                                                       | `Session`           | Y        | `undefined`   |
+| `transports`            | Array of transports that should be used                                                | `Transport[]`       | N        |               |
+| `user`                  | User metadata                                                                          | `User`              | Y        | `undefined`   |
+| `parseStacktrace`       | Stack trace parser                                                                     | `StacktraceParser`  | N        |               |
+| `paused`                | Should the agent start paused                                                          | `boolean`           | Y        | `false`       |
 
 ## Agent
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -221,3 +221,9 @@ initializeAgent({
   transports: [new MyTransport()],
 });
 ```
+
+## Pause / unpause
+
+Agent can be paused by invoking `agent.pause()`.
+This will prevent events from being sent to transports.
+Call `agent.unpause()` to resume capturing events.

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -1,0 +1,43 @@
+import type { LogEvent } from './api';
+import { initializeAgent } from './initialize';
+import type { TransportItem } from './transports';
+import { mockConfig, MockTransport } from './utils/tests';
+
+describe('agent', () => {
+  it(`can be started paused and doesn't ingest events until unpaused`, () => {
+    const transport = new MockTransport();
+    const config = mockConfig({
+      paused: true,
+      transports: [transport],
+    });
+
+    const agent = initializeAgent(config);
+    agent.api.pushLog(['test']);
+    expect(transport.items).toHaveLength(0);
+    agent.unpause();
+    agent.api.pushLog(['test2']);
+    expect(transport.items).toHaveLength(1);
+    const item = transport.items[0]! as TransportItem<LogEvent>;
+    expect(item.payload.message).toEqual('test2');
+  });
+
+  it('can be started unpaused, then paused and unpaused again', () => {
+    const transport = new MockTransport();
+    const config = mockConfig({
+      transports: [transport],
+    });
+    const agent = initializeAgent(config);
+    agent.api.pushLog(['test1']);
+    expect(transport.items).toHaveLength(1);
+    agent.pause();
+    agent.api.pushLog(['test2']);
+    expect(transport.items).toHaveLength(1);
+    agent.unpause();
+    agent.api.pushLog(['test3']);
+    const items = transport.items as Array<TransportItem<LogEvent>>;
+    expect(items[0]?.payload.message).toEqual('test1');
+    expect(items[1]?.payload.message).toEqual('test3');
+  });
+});
+
+export {};

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -12,6 +12,7 @@ export interface Config<P = APIEvent> {
   app: App;
   parseStacktrace: StacktraceParser;
 
+  paused?: boolean;
   session?: Session;
   user?: User;
   beforeSend?: BeforeSendHook<P>;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -11,8 +11,8 @@ export interface Config<P = APIEvent> {
   metas: MetaItem[];
   app: App;
   parseStacktrace: StacktraceParser;
+  paused: boolean;
 
-  paused?: boolean;
   session?: Session;
   user?: User;
   beforeSend?: BeforeSendHook<P>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export { BaseInstrumentation } from './instrumentations';
 export type { Meta, MetaGetter, Metas, MetaItem, App, User, Session } from './metas';
 
 export { getTransportBody, TransportItemType } from './transports';
-export type { Transport, TransportBody, TransportItem, TransportItemPayload, Transports } from './transports';
+export type { Transport, TransportBody, TransportItem, TransportItemPayload, Transports, BeforeSendHook } from './transports';
 export { BaseTransport } from './transports';
 
 export * from './utils';

--- a/packages/core/src/initialize.ts
+++ b/packages/core/src/initialize.ts
@@ -12,11 +12,16 @@ export function initializeAgent(config: Config): Agent {
   const transports = initializeTransports(config);
   const api = initializeAPI(config, transports, metas);
 
+  const pause = () => transports.pause();
+  const unpause = () => transports.unpause();
+
   const agent = initializeGlobalAgent({
     config,
     metas,
     transports,
     api,
+    pause,
+    unpause
   });
 
   if (!agent.config.preventGlobalExposure) {

--- a/packages/core/src/initialize.ts
+++ b/packages/core/src/initialize.ts
@@ -21,7 +21,7 @@ export function initializeAgent(config: Config): Agent {
     transports,
     api,
     pause,
-    unpause
+    unpause,
   });
 
   if (!agent.config.preventGlobalExposure) {

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -7,7 +7,7 @@ import { BeforeSendHook, Transport, TransportItemType, Transports } from './type
 export function initializeTransports(config: Config): Transports {
   const transports: Transport[] = [...config.transports];
 
-  let paused = config.paused ?? false;
+  let paused = config.paused;
 
   const beforeSendHooks: BeforeSendHook[] = [];
   if (config.beforeSend) {

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -7,7 +7,7 @@ import { BeforeSendHook, Transport, TransportItemType, Transports } from './type
 export function initializeTransports(config: Config): Transports {
   const transports: Transport[] = [...config.transports];
 
-  let paused = false;
+  let paused = config.paused ?? false;
 
   const beforeSendHooks: BeforeSendHook[] = [];
   if (config.beforeSend) {
@@ -39,18 +39,18 @@ export function initializeTransports(config: Config): Transports {
 
   const pause = () => {
     paused = true;
-  }
+  };
 
   const unpause = () => {
     paused = false;
-  }
+  };
 
   return {
     add,
     execute,
     transports,
     pause,
-    unpause
+    unpause,
   };
 }
 

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -37,4 +37,6 @@ export interface Transports {
   add: (...transports: Transport[]) => void;
   execute: (transportItem: TransportItem) => void;
   transports: Transport[];
+  pause: () => void;
+  unpause: () => void;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,4 +8,6 @@ export interface Agent {
   config: Config;
   metas: Metas;
   transports: Transports;
+  pause: () => void;
+  unpause: () => void;
 }

--- a/packages/core/src/utils/tests.ts
+++ b/packages/core/src/utils/tests.ts
@@ -29,6 +29,7 @@ export function mockConfig(overrides: Partial<Config> = {}): Config {
       version: '1.0.0',
     },
     parseStacktrace: mockStacktraceParser,
+    paused: false,
     ...overrides,
   };
 }

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -8,6 +8,8 @@ import {
   defaultGlobalObjectKey,
   Transport,
   Patterns,
+  APIEvent,
+  BeforeSendHook,
 } from '@grafana/agent-core';
 
 import {
@@ -20,9 +22,10 @@ import { browserMeta, pageMeta } from './metas';
 import { FetchTransport } from './transports';
 
 export interface BrowserConfig {
+  app: App;
+
   url?: string;
   apiKey?: string;
-  app: App;
   session?: Session;
   user?: User;
   globalObjectKey?: string;
@@ -31,6 +34,8 @@ export interface BrowserConfig {
   instrumentations?: Instrumentation[];
   transports?: Transport[];
   ignoreErrors?: Patterns;
+  beforeSend?: BeforeSendHook<APIEvent>;
+  paused?: boolean;
 }
 
 export const defaultMetas: MetaItem[] = [browserMeta, pageMeta];
@@ -78,6 +83,8 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     user: browserConfig.user,
     ignoreErrors: browserConfig.ignoreErrors,
     parseStacktrace,
+    paused: browserConfig.paused,
+    beforeSend: browserConfig.beforeSend,
   };
 
   return config;

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -83,7 +83,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     user: browserConfig.user,
     ignoreErrors: browserConfig.ignoreErrors,
     parseStacktrace,
-    paused: browserConfig.paused,
+    paused: browserConfig.paused ?? false,
     beforeSend: browserConfig.beforeSend,
   };
 


### PR DESCRIPTION
Adds ability to pause the agent, preventing events from being sent to transports.
Can be used when you do not want to track certain pages in your SPA.
Alternative to https://github.com/grafana/grafana-javascript-agent/pull/29