### PR TITLE
Events API

### DIFF
--- a/cypress/e2e/demo/events.cy.ts
+++ b/cypress/e2e/demo/events.cy.ts
@@ -1,0 +1,12 @@
+context('Events', () => {
+  it('will capture an event', () => {
+    cy.clickButton('btn-event-with-attrs');
+
+    cy.waitEvents((events) => {
+      expect(events).to.have.lengthOf(1);
+      const event = events[0]!;
+      expect(event).property('name').to.equal('click_button_with_attributes');
+      expect(event).property('attributes').property('foo').to.equal('bar');
+    });
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,5 @@
 import type { ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent, TransportBody } from '@grafana/agent-core';
+import type { EventEvent } from 'packages/core/src/api/events';
 
 Cypress.Commands.add('waitLogs', (fn: (evts: LogEvent[]) => void) => {
   cy.wait('@logs').then((interception) => fn((interception.request.body as TransportBody).logs!));
@@ -10,6 +11,10 @@ Cypress.Commands.add('waitExceptions', (fn: (evts: ExceptionEvent[]) => void) =>
 
 Cypress.Commands.add('waitTraces', (fn: (evts: TraceEvent) => void) => {
   cy.wait('@traces').then((interception) => fn((interception.request.body as TransportBody).traces!));
+});
+
+Cypress.Commands.add('waitEvents', (fn: (evts: EventEvent[]) => void) => {
+  cy.wait('@events').then((interception) => fn((interception.request.body as TransportBody).events!));
 });
 
 Cypress.Commands.add('waitMeasurements', (fn: (evts: MeasurementEvent[]) => void, count = 1) => {
@@ -39,6 +44,7 @@ declare global {
       waitExceptions(fn: (evts: ExceptionEvent[]) => void): Chainable<void>;
       waitMeasurements(fn: (evts: MeasurementEvent[]) => void, count?: number): Chainable<void>;
       waitTraces(fn: (evt: TraceEvent) => void): Chainable<void>;
+      waitEvents(fn: (evts: EventEvent[]) => void): Chainable<void>;
       clickButton(dataname: string): Chainable<void>;
       loadBlank(): Chainable<void>;
     }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,11 @@
-import type { ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent, TransportBody } from '@grafana/agent-core';
-import type { EventEvent } from 'packages/core/src/api/events';
+import type {
+  ExceptionEvent,
+  LogEvent,
+  MeasurementEvent,
+  TraceEvent,
+  TransportBody,
+  EventEvent,
+} from '@grafana/agent-core';
 
 Cypress.Commands.add('waitLogs', (fn: (evts: LogEvent[]) => void) => {
   cy.wait('@logs').then((interception) => fn((interception.request.body as TransportBody).logs!));

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,10 +1,10 @@
 import type {
+  EventEvent,
   ExceptionEvent,
   LogEvent,
   MeasurementEvent,
   TraceEvent,
   TransportBody,
-  EventEvent,
 } from '@grafana/agent-core';
 
 Cypress.Commands.add('waitLogs', (fn: (evts: LogEvent[]) => void) => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -13,6 +13,8 @@ beforeEach(() => {
       req.alias = 'traces';
     } else if (body.measurements?.length) {
       req.alias = 'measurements';
+    } else if (body.events?.length) {
+      req.alias = 'events';
     }
     req.reply({
       statusCode: 201,

--- a/dashboards/frontend-application.json
+++ b/dashboards/frontend-application.json
@@ -9,7 +9,7 @@
       "pluginName": "Loki"
     }
   ],
-  "__elements": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
@@ -68,7 +68,6 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1655814818965,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -434,6 +433,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -490,7 +491,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -548,6 +550,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -607,7 +611,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -641,6 +646,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -701,7 +708,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -808,6 +816,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -879,7 +889,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1318,6 +1329,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1389,7 +1402,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1411,10 +1425,121 @@
       ],
       "title": "Visits",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 32,
+      "panels": [],
+      "title": "Events",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOGS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "id": 35,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Count"
+          }
+        ]
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOGS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, count(count_over_time({kind=\"event\", app=\"$app\"} | logfmt [$__range])) by (event_name))",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Events",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Count",
+              "event_name": "Name",
+              "value": "Error"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "refresh": "",
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1442,12 +1567,12 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Frontend",
-  "version": 13,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboards/grafana-agent-receiver.json
+++ b/dashboards/grafana-agent-receiver.json
@@ -9,13 +9,13 @@
       "pluginName": "Prometheus"
     }
   ],
-  "__elements": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.0.3-0dc0087e"
+      "version": "9.0.0"
     },
     {
       "type": "datasource",
@@ -62,7 +62,6 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1657178846545,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -110,7 +109,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
@@ -173,7 +172,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
@@ -236,7 +235,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
@@ -273,10 +272,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "dark-red",
-                "value": 1
               }
             ]
           }
@@ -289,7 +284,7 @@
         "x": 6,
         "y": 0
       },
-      "id": 11,
+      "id": 20,
       "interval": "5m",
       "options": {
         "colorMode": "value",
@@ -303,22 +298,23 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${PROMETHEUS}"
           },
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(app_agent_receiver_exporter_errors_total{instance=\"$instance\"}[$__range]))",
+          "expr": "sum(increase(app_agent_receiver_events_total{instance=\"$instance\"}[$__range]))",
           "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Exporter errors",
+      "title": "Events",
       "type": "stat"
     },
     {
@@ -364,7 +360,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
@@ -429,7 +425,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
@@ -445,6 +441,73 @@
         }
       ],
       "title": "Rate Limited Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 12,
+        "y": 0
+      },
+      "id": 11,
+      "interval": "5m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "sum(increase(app_agent_receiver_exporter_errors_total{instance=\"$instance\"}[$__range]))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Processing errors",
       "type": "stat"
     },
     {
@@ -477,7 +540,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 12,
+        "x": 14,
         "y": 0
       },
       "id": 19,
@@ -493,7 +556,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.3-0dc0087e",
+      "pluginVersion": "9.0.0",
       "targets": [
         {
           "datasource": {
@@ -501,7 +564,7 @@
             "uid": "${PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(app_agent_receiver_sourcemap_cache_size{instance=\"auth-app-production\"})",
+          "expr": "sum(app_agent_receiver_sourcemap_cache_size{instance=\"$instance\"})",
           "legendFormat": "sourcemaps cached",
           "range": true,
           "refId": "A"
@@ -521,6 +584,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -577,7 +642,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -639,6 +705,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -711,7 +779,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -755,9 +824,23 @@
           "interval": "",
           "legendFormat": "measurements",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(increase(app_agent_receiver_events_total{instance=\"$instance\"}[$__interval]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "events",
+          "range": true,
+          "refId": "D"
         }
       ],
-      "title": "Events ingested",
+      "title": "Telemetry ingested",
       "type": "timeseries"
     },
     {
@@ -771,6 +854,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -842,7 +927,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -877,6 +963,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -923,7 +1011,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 12,
         "y": 13
@@ -934,7 +1022,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -971,7 +1060,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1007,6 +1096,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Receiver",
-  "version": 6,
+  "version": 3,
   "weekStart": ""
 }

--- a/demo/src/actions.ts
+++ b/demo/src/actions.ts
@@ -56,6 +56,6 @@ localWindow.traceWithLog = () => {
   }
 };
 
-w.captureEvent = (name: string, attributes?: Record<string, string>) => {
+localWindow.captureEvent = (name: string, attributes?: Record<string, string>) => {
   window.grafanaAgent.api.pushEvent(name, attributes);
 };

--- a/demo/src/actions.ts
+++ b/demo/src/actions.ts
@@ -55,3 +55,7 @@ localWindow.traceWithLog = () => {
     });
   }
 };
+
+w.captureEvent = (name: string, attributes?: Record<string, string>) => {
+  window.grafanaAgent.api.pushEvent(name, attributes);
+};

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -8,15 +8,14 @@
     <h1>Grafana JavaScript Agent Demo - Home</h1>
     <hr />
 
-    <a href="./index.html" class="active">Home</a> |
-    <a href="./another-page.html">Another page</a> |
+    <a href="./index.html" class="active">Home</a> | <a href="./another-page.html">Another page</a> |
     <a href="./cls.html">CLS Test Page</a>
     <hr />
 
     <h2>Console Instrumentation</h2>
     <button data-cy="btn-log-trace" onclick="callConsole('trace')">Trace</button>
     <button data-cy="btn-log-info" onclick="callConsole('info')">Info</button>
-    <button data-cy="btn-log-log"  onclick="callConsole('log')">Log</button>
+    <button data-cy="btn-log-log" onclick="callConsole('log')">Log</button>
     <button data-cy="btn-log-warn" onclick="callConsole('warn')">Warn</button>
     <button data-cy="btn-log-error" onclick="callConsole('error')">Error</button>
     <hr />
@@ -37,6 +36,16 @@
 
     <h2>Metrics Measurements</h2>
     <button onclick="sendCustomMetric()">Send custom metric</button>
+    <hr />
+
+    <h2>Events</h2>
+    <button onclick="captureEvent('click_button_no_attributes')">Capture click event, no attrs</button>
+    <button
+      data-cy="btn-event-with-attrs"
+      onclick="captureEvent('click_button_with_attributes', { foo: 'bar', baz: 'bad' })"
+    >
+      Capture click event, with attrs
+    </button>
     <hr />
 
     <script src="index.ts" type="module"></script>

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -266,9 +266,9 @@ console.info("Hello world", 123);
 agent.api.pushLog(["Hello world", 123], { level: LogLevel.Debug });
 
 // log with context
-agent.api.pushLog(["Navigation"], {
+agent.api.pushLog(["Sending update"], {
   context: {
-    url: window.location.href
+    payload: thePayload,
   },
   level: LogLevel.Trace
 });
@@ -292,8 +292,11 @@ agent.api.pushMeasurement({
   }
 });
 
-// push an Error
+// push an error
 agent.api.pushError(new Error('everything went horribly wrong'));
+
+// push an event
+agent.api.pushEvent('navigation', { url: window.location.href });
 
 // pause agent, preventing events from being sent
 agent.pause()

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,6 +39,7 @@ Besides the mandatory properties, the agent also supports the following optional
 | Property       | Description                                                                            | Type             | Default Value |
 | -------------- | -------------------------------------------------------------------------------------- | ---------------- | ------------- |
 | `beforeSend`   | Hook invoked before pushing event to transport. Can be used to modify or filter events | `BeforeSendHook` | `undefined`   |
+| `eventDomain`  | event.domain attribute of an event, to be set on every event item as default           | `string`         | `undefined`   |
 | `ignoreErrors` | Error message patterns for errors that should be ignored                               | `Patterns`       | `[]`          |
 | `session`      | Session metadata                                                                       | `Session`        | `undefined`   |
 | `user`         | User metadata                                                                          | `User`           | `undefined`   |

--- a/packages/core/src/api/events/index.ts
+++ b/packages/core/src/api/events/index.ts
@@ -1,0 +1,2 @@
+export type { EventEvent, EventsAPI } from './types';
+export { initializeEventsAPI } from './initialize';

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -1,0 +1,37 @@
+import type { Config } from '../../config';
+import type { InternalLogger } from '../../internalLogger';
+import type { Metas } from '../../metas';
+import { TransportItem, TransportItemType, Transports } from '../../transports';
+import { getCurrentTimestamp } from '../../utils';
+import type { TracesAPI } from '../traces';
+import type { EventEvent, EventsAPI } from './types';
+
+export function initializeEventsAPI(
+  internalLogger: InternalLogger,
+  config: Config,
+  transports: Transports,
+  metas: Metas,
+  tracesApi: TracesAPI
+): EventsAPI {
+  const pushEvent: EventsAPI['pushEvent'] = (name, attributes, domain) => {
+    const item: TransportItem<EventEvent> = {
+      meta: metas.value,
+      payload: {
+        name,
+        domain: domain ?? config.eventDomain,
+        attributes,
+        timestamp: getCurrentTimestamp(),
+        trace: tracesApi.getTraceContext(),
+      },
+      type: TransportItemType.EVENT,
+    };
+
+    internalLogger.debug('Pushing event', item);
+
+    transports.execute(item);
+  };
+
+  return {
+    pushEvent,
+  };
+}

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -1,7 +1,7 @@
 import type { Config } from '../../config';
 import type { InternalLogger } from '../../internalLogger';
 import type { Metas } from '../../metas';
-import { TransportItem, TransportItemType, Transports } from '../../transports';
+import type { TransportItem, TransportItemType, Transports } from '../../transports';
 import { getCurrentTimestamp } from '../../utils';
 import type { TracesAPI } from '../traces';
 import type { EventEvent, EventsAPI } from './types';
@@ -26,7 +26,7 @@ export function initializeEventsAPI(
       type: TransportItemType.EVENT,
     };
 
-    internalLogger.debug('Pushing event', item);
+    internalLogger.debug('Pushing event\n', item);
 
     transports.execute(item);
   };

--- a/packages/core/src/api/events/types.ts
+++ b/packages/core/src/api/events/types.ts
@@ -1,0 +1,16 @@
+import type { TraceContext } from '../traces';
+
+export type EventAttributes = Record<string, string>;
+
+export interface EventEvent {
+  name: string;
+  timestamp: string;
+
+  domain?: string;
+  attributes?: EventAttributes;
+  trace?: TraceContext;
+}
+
+export interface EventsAPI {
+  pushEvent: (name: string, attributes?: EventAttributes, domain?: string) => void;
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -20,4 +20,4 @@ export type { MetaAPI } from './meta';
 
 export type { InstrumentationLibrarySpan, ResourceSpan, TraceContext, TraceEvent, TracesAPI } from './traces';
 
-export type { EventEvent } from './events';
+export type { EventEvent, EventsAPI } from './events';

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -19,3 +19,5 @@ export type { MeasurementEvent, MeasurementsAPI, PushMeasurementOptions } from '
 export type { MetaAPI } from './meta';
 
 export type { InstrumentationLibrarySpan, ResourceSpan, TraceContext, TraceEvent, TracesAPI } from './traces';
+
+export type { EventEvent } from './events';

--- a/packages/core/src/api/initialize.ts
+++ b/packages/core/src/api/initialize.ts
@@ -2,6 +2,7 @@ import type { Config } from '../config';
 import type { InternalLogger } from '../internalLogger';
 import type { Metas } from '../metas';
 import type { Transports } from '../transports';
+import { initializeEventsAPI } from './events';
 import { initializeExceptionsAPI } from './exceptions';
 import { initializeLogsAPI } from './logs';
 import { initializeMeasurementsAPI } from './measurements';
@@ -25,5 +26,6 @@ export function initializeAPI(
     ...initializeMetaAPI(internalLogger, transports, metas),
     ...initializeLogsAPI(internalLogger, transports, metas, tracesApi),
     ...initializeMeasurementsAPI(internalLogger, transports, metas, tracesApi),
+    ...initializeEventsAPI(internalLogger, config, transports, metas, tracesApi),
   };
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,9 +1,10 @@
+import type { EventEvent, EventsAPI } from './events';
 import type { ExceptionsAPI, ExceptionEvent } from './exceptions';
 import type { LogsAPI, LogEvent } from './logs';
 import type { MeasurementsAPI, MeasurementEvent } from './measurements';
 import type { MetaAPI } from './meta';
 import type { TracesAPI, TraceEvent } from './traces';
 
-export type APIEvent = LogEvent | ExceptionEvent | MeasurementEvent | TraceEvent;
+export type APIEvent = LogEvent | ExceptionEvent | MeasurementEvent | TraceEvent | EventEvent;
 
-export type API = LogsAPI & ExceptionsAPI & MeasurementsAPI & TracesAPI & MetaAPI;
+export type API = LogsAPI & ExceptionsAPI & MeasurementsAPI & TracesAPI & MetaAPI & EventsAPI;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -22,6 +22,7 @@ export interface Config<P = APIEvent> {
   ignoreErrors?: Patterns;
   session?: MetaSession;
   user?: MetaUser;
+  eventDomain?: string;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,8 @@ export type {
   TraceContext,
   TraceEvent,
   TracesAPI,
+  EventEvent,
+  EventsAPI,
 } from './api';
 
 export { globalObject } from './globalObject';

--- a/packages/core/src/transports/const.ts
+++ b/packages/core/src/transports/const.ts
@@ -3,6 +3,7 @@ export enum TransportItemType {
   LOG = 'log',
   MEASUREMENT = 'measurement',
   TRACE = 'trace',
+  EVENT = 'event',
 }
 
 export const transportItemTypeToBodyKey: Record<TransportItemType, string> = {
@@ -10,4 +11,5 @@ export const transportItemTypeToBodyKey: Record<TransportItemType, string> = {
   [TransportItemType.LOG]: 'logs',
   [TransportItemType.MEASUREMENT]: 'measurements',
   [TransportItemType.TRACE]: 'traces',
+  [TransportItemType.EVENT]: 'events',
 } as const;

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -1,5 +1,4 @@
-import type { APIEvent, ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent } from '../api';
-import type { EventEvent } from '../api/events';
+import type { APIEvent, ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent, EventEvent } from '../api';
 import type { Patterns } from '../config';
 import type { Meta } from '../metas';
 import type { Extension } from '../utils';

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -1,4 +1,4 @@
-import type { APIEvent, ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent, EventEvent } from '../api';
+import type { APIEvent, EventEvent, ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent } from '../api';
 import type { Patterns } from '../config';
 import type { Meta } from '../metas';
 import type { Extension } from '../utils';

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -1,4 +1,5 @@
 import type { APIEvent, ExceptionEvent, LogEvent, MeasurementEvent, TraceEvent } from '../api';
+import type { EventEvent } from '../api/events';
 import type { Patterns } from '../config';
 import type { Meta } from '../metas';
 import type { Extension } from '../utils';
@@ -28,6 +29,7 @@ export interface TransportBody {
   logs?: LogEvent[];
   measurements?: MeasurementEvent[];
   traces?: TraceEvent;
+  events?: EventEvent[];
 }
 
 export interface Transports {

--- a/packages/web/src/config/makeCoreConfig.ts
+++ b/packages/web/src/config/makeCoreConfig.ts
@@ -6,6 +6,7 @@ import {
 } from '@grafana/agent-core';
 import type { Config, Transport } from '@grafana/agent-core';
 
+import { BROWSER_EVENT_DOMAIN } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { defaultMetas } from '../metas';
 import { FetchTransport } from '../transports';
@@ -51,6 +52,6 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     ignoreErrors: browserConfig.ignoreErrors,
     session: browserConfig.session,
     user: browserConfig.user,
-    eventDomain: browserConfig.eventDomain ?? 'browser',
+    eventDomain: browserConfig.eventDomain ?? BROWSER_EVENT_DOMAIN,
   };
 }

--- a/packages/web/src/config/makeCoreConfig.ts
+++ b/packages/web/src/config/makeCoreConfig.ts
@@ -51,5 +51,6 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     ignoreErrors: browserConfig.ignoreErrors,
     session: browserConfig.session,
     user: browserConfig.user,
+    eventDomain: browserConfig.eventDomain ?? 'browser',
   };
 }

--- a/packages/web/src/consts.ts
+++ b/packages/web/src/consts.ts
@@ -1,0 +1,1 @@
+export const BROWSER_EVENT_DOMAIN = 'browser';

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -126,4 +126,8 @@ export type {
   TransportItemPayload,
   Transports,
   UnpatchedConsole,
+  EventEvent,
+  EventsAPI,
 } from '@grafana/agent-core';
+
+export { BROWSER_EVENT_DOMAIN } from './consts';


### PR DESCRIPTION
Adds `agent.api.pushEvent`, aligned as much as possible with [Events API OTEP](https://github.com/open-telemetry/oteps/blob/main/text/0202-events-and-logs-api.md). [Sister PR on the receiver side](https://github.com/grafana/agent/pull/2075).

Example:

```typescript
agent.api.pushEvent('navigation', { url: window.location.href });
```

Event domain defaults to `browser` for the web, to align with [otel semantics proposal](https://github.com/martinkuba/opentelemetry-specification/pull/1/files).

Open question: should we compile a set of semantic consts for common event names and attributes?..

fixes #48 

TODO:
- [x] update dashboards