### PR TITLE
Session instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Basic session tracking: web SDK automatically creates new session id when agent is initialized.
+  `SessionInstrumentation` that sends `session_start` event on initialization or when new session
+  is set. `SessionProcessor` for OTel that will add `session_id` attribute to every span if available.
+- Added `agent.api.pushEvent` method for capturing RUM events
+
 ## 0.4.0 (2022-06-30)
 
 - Added `agent.pause()` and `agent.unpause()` to be able to temporarily stop

--- a/cypress/e2e/demo/events.cy.ts
+++ b/cypress/e2e/demo/events.cy.ts
@@ -1,12 +1,28 @@
-context('Events', () => {
-  it('will capture an event', () => {
-    cy.clickButton('btn-event-with-attrs');
+import { Conventions } from '@grafana/agent-core';
 
+context('Events', () => {
+  it('will capture a click event', () => {
+    cy.clickButton('btn-event-with-attrs');
+    cy.waitEvents(() => {}); // skip session event
     cy.waitEvents((events) => {
       expect(events).to.have.lengthOf(1);
       const event = events[0]!;
       expect(event).property('name').to.equal('click_button_with_attributes');
       expect(event).property('attributes').property('foo').to.equal('bar');
+    });
+  });
+
+  it('will capture starts session event', () => {
+    cy.waitEvents((events) => {
+      expect(events).to.have.lengthOf(1);
+      const event = events[0]!;
+      expect(event).property('name').to.equal(Conventions.EventNames.SESSION_START);
+    });
+    cy.clickButton('btn-new-session');
+    cy.waitEvents((events) => {
+      expect(events).to.have.lengthOf(1);
+      const event = events[0]!;
+      expect(event).property('name').to.equal(Conventions.EventNames.SESSION_START);
     });
   });
 });

--- a/demo/src/actions.ts
+++ b/demo/src/actions.ts
@@ -1,4 +1,5 @@
 import '@grafana/agent-web/globals';
+import { createSession } from '@grafana/agent-web';
 import { SpanStatusCode } from '@opentelemetry/api';
 
 const localWindow: any = window;
@@ -58,4 +59,8 @@ localWindow.traceWithLog = () => {
 
 localWindow.captureEvent = (name: string, attributes?: Record<string, string>) => {
   window.grafanaAgent.api.pushEvent(name, attributes);
+};
+
+localWindow.startNewSession = () => {
+  window.grafanaAgent.api.setSession(createSession());
 };

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -46,6 +46,12 @@
     >
       Capture click event, with attrs
     </button>
+    <button
+      data-cy="btn-new-session"
+      onclick="startNewSession()"
+    >
+      Start new session
+    </button
     <hr />
 
     <script src="index.ts" type="module"></script>

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -4,7 +4,7 @@ import { initializeGrafanaAgent, getWebInstrumentations } from '@grafana/agent-w
 
 initializeGrafanaAgent({
   isolate: true,
-  url: '/collect',
+  url: 'http://localhost:12345/collect',
   apiKey: 'secret',
   instrumentations: [...getWebInstrumentations(), new TracingInstrumentation()],
   internalLoggerLevel: InternalLoggerLevel.VERBOSE,

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -285,6 +285,15 @@ agent.api.setUser({
   }
 });
 
+// unset user
+agent.api.resetUser();
+
+// set session metadata, to be included with every event
+agent.api.setSession(createSession({ plan: 'paid' }));
+
+// unset session
+agent.api.resetSession();
+
 // push measurement
 agent.api.pushMeasurement({
   type: 'cart-transaction',

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -130,6 +130,7 @@ import {
   initializeGrafanaAgent,
   LogLevel,
   WebVitalsInstrumentation,
+  SessionInstrumentation,
 } from '@grafana/agent-web';
 
 const agent = initializeGrafanaAgent({
@@ -139,6 +140,7 @@ const agent = initializeGrafanaAgent({
     new ConsoleInstrumentation({
       disabledLevels: [LogLevel.TRACE, LogLevel.ERROR], // console.log will be captured
     }),
+    new SessionInstrumentation(),
   ],
   transports: [
     new FetchTransport({
@@ -206,7 +208,7 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { initializeGrafanaAgent } from '@grafana/agent-web';
-import { GrafanaAgentTraceExporter } from '@grafana/agent-trace-web';
+import { GrafanaAgentTraceExporter, SessionProcessor } from '@grafana/agent-trace-web';
 
 const VERSION = '1.0.0';
 const NAME = 'frontend';
@@ -231,7 +233,7 @@ const resource = Resource.default().merge(
 );
 
 const provider = new WebTracerProvider({ resource });
-provider.addSpanProcessor(new BatchSpanProcessor(new GrafanaAgentTraceExporter({ agent })));
+provider.addSpanProcessor(new SessionSpanProcessor(new BatchSpanProcessor(new GrafanaAgentTraceExporter({ agent }))));
 provider.register({
   propagator: new W3CTraceContextPropagator(),
   contextManager: new ZoneContextManager(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,11 +37,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",
     "@opentelemetry/api-metrics": "^0.31.0",
-    "@opentelemetry/otlp-transformer": "^0.31.0",
-    "uuid": "^8.3.2"
-  },
-  "devDependencies": {
-    "@types/uuid": "^8.3.4"
+    "@opentelemetry/otlp-transformer": "^0.31.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -6,15 +6,34 @@ import type { MetaAPI } from './types';
 export function initializeMetaAPI(internalLogger: InternalLogger, _transports: Transports, metas: Metas): MetaAPI {
   internalLogger.debug('Initializing meta API');
 
-  let meta: Meta = {};
+  let metaSession: Partial<Meta> | undefined = undefined;
+  let metaUser: Partial<Meta> | undefined = undefined;
 
-  metas.add(() => meta);
-
-  const setUser: MetaAPI['setUser'] = (user: MetaUser | null) => {
-    meta = { ...meta, user: user ?? undefined };
+  const setUser: MetaAPI['setUser'] = (user?: MetaUser) => {
+    if (metaUser) {
+      metas.remove(metaUser);
+    }
+    metaUser = {
+      user,
+    };
+    metas.add(metaUser);
   };
+
+  const setSession: MetaAPI['setSession'] = (session) => {
+    if (metaSession) {
+      metas.remove(metaSession);
+    }
+    metaSession = {
+      session,
+    };
+    metas.add(metaSession);
+  };
+
+  const getSession: MetaAPI['getSession'] = () => metas.value.session;
 
   return {
     setUser,
+    setSession,
+    getSession,
   };
 }

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -35,10 +35,10 @@ export function initializeMetaAPI(internalLogger: InternalLogger, _transports: T
   const getSession: MetaAPI['getSession'] = () => metas.value.session;
 
   return {
-    setUser: (user) => setUser(user),
-    resetUser: () => setUser(),
-    setSession: (session) => setSession(session),
-    resetSession: () => setSession(),
+    setUser,
+    resetUser: setUser,
+    setSession,
+    resetSession: setSession,
     getSession,
   };
 }

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -13,9 +13,11 @@ export function initializeMetaAPI(internalLogger: InternalLogger, _transports: T
     if (metaUser) {
       metas.remove(metaUser);
     }
+
     metaUser = {
       user,
     };
+
     metas.add(metaUser);
   };
 
@@ -26,6 +28,7 @@ export function initializeMetaAPI(internalLogger: InternalLogger, _transports: T
     metaSession = {
       session,
     };
+
     metas.add(metaSession);
   };
 

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -1,5 +1,5 @@
 import type { InternalLogger } from '../../internalLogger';
-import type { Meta, Metas, MetaUser } from '../../metas';
+import type { Meta, Metas, MetaSession, MetaUser } from '../../metas';
 import type { Transports } from '../../transports';
 import type { MetaAPI } from './types';
 
@@ -9,7 +9,7 @@ export function initializeMetaAPI(internalLogger: InternalLogger, _transports: T
   let metaSession: Partial<Meta> | undefined = undefined;
   let metaUser: Partial<Meta> | undefined = undefined;
 
-  const setUser: MetaAPI['setUser'] = (user?: MetaUser) => {
+  const setUser = (user?: MetaUser) => {
     if (metaUser) {
       metas.remove(metaUser);
     }
@@ -21,7 +21,7 @@ export function initializeMetaAPI(internalLogger: InternalLogger, _transports: T
     metas.add(metaUser);
   };
 
-  const setSession: MetaAPI['setSession'] = (session) => {
+  const setSession = (session?: MetaSession) => {
     if (metaSession) {
       metas.remove(metaSession);
     }
@@ -35,8 +35,10 @@ export function initializeMetaAPI(internalLogger: InternalLogger, _transports: T
   const getSession: MetaAPI['getSession'] = () => metas.value.session;
 
   return {
-    setUser,
-    setSession,
+    setUser: (user) => setUser(user),
+    resetUser: () => setUser(),
+    setSession: (session) => setSession(session),
+    resetSession: () => setSession(),
     getSession,
   };
 }

--- a/packages/core/src/api/meta/types.ts
+++ b/packages/core/src/api/meta/types.ts
@@ -1,7 +1,9 @@
 import type { MetaSession, MetaUser } from '../../metas';
 
 export interface MetaAPI {
-  setUser: (user?: MetaUser) => void;
-  setSession: (session?: MetaSession) => void;
+  setUser: (user: MetaUser) => void;
+  resetUser: () => void;
+  setSession: (session: MetaSession) => void;
+  resetSession: () => void;
   getSession: () => MetaSession | undefined;
 }

--- a/packages/core/src/api/meta/types.ts
+++ b/packages/core/src/api/meta/types.ts
@@ -1,5 +1,7 @@
-import type { MetaUser } from '../../metas';
+import type { MetaSession, MetaUser } from '../../metas';
 
 export interface MetaAPI {
-  setUser: (user: MetaUser | null) => void;
+  setUser: (user?: MetaUser) => void;
+  setSession: (session?: MetaSession) => void;
+  getSession: () => MetaSession | undefined;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,3 +121,5 @@ export type {
 } from './utils';
 
 export { VERSION } from './version';
+
+export { Events } from './semantic';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,7 @@ export {
   BaseExtension,
   createPromiseBuffer,
   defaultLogLevel,
+  genShortID,
   getCurrentTimestamp,
   isArray,
   isBoolean,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,4 +122,4 @@ export type {
 
 export { VERSION } from './version';
 
-export { Events } from './semantic';
+export { Conventions } from './semantic';

--- a/packages/core/src/initialize.ts
+++ b/packages/core/src/initialize.ts
@@ -26,7 +26,9 @@ export function initializeGrafanaAgent(config: Config): Agent {
   const transports = initializeTransports(internalLogger, config);
   const api = initializeAPI(internalLogger, config, transports, metas);
 
-  api.setSession(config.session);
+  if (config.session) {
+    api.setSession(config.session);
+  }
 
   const agent = initializeAgent(internalLogger, {
     api,

--- a/packages/core/src/initialize.ts
+++ b/packages/core/src/initialize.ts
@@ -37,7 +37,7 @@ export function initializeGrafanaAgent(config: Config): Agent {
     transports,
     unpatchedConsole,
     unpause: transports.unpause,
-    instrumentations: initializeInstrumentations(internalLogger),
+    instrumentations: initializeInstrumentations(internalLogger, config),
   });
 
   // make sure agent is initialized before initializing instrumentations

--- a/packages/core/src/initialize.ts
+++ b/packages/core/src/initialize.ts
@@ -26,6 +26,8 @@ export function initializeGrafanaAgent(config: Config): Agent {
   const transports = initializeTransports(internalLogger, config);
   const api = initializeAPI(internalLogger, config, transports, metas);
 
+  api.setSession(config.session);
+
   const agent = initializeAgent(internalLogger, {
     api,
     config,
@@ -35,9 +37,11 @@ export function initializeGrafanaAgent(config: Config): Agent {
     transports,
     unpatchedConsole,
     unpause: transports.unpause,
-  } as Agent);
+    instrumentations: initializeInstrumentations(internalLogger),
+  });
 
-  agent.instrumentations = initializeInstrumentations(agent.internalLogger, agent.config);
+  // make sure agent is initialized before initializing instrumentations
+  agent.instrumentations.add(...config.instrumentations);
 
   return agent;
 }

--- a/packages/core/src/instrumentations/initialize.ts
+++ b/packages/core/src/instrumentations/initialize.ts
@@ -1,7 +1,8 @@
+import type { Config } from '../config';
 import type { InternalLogger } from '../internalLogger';
 import type { Instrumentation, Instrumentations } from './types';
 
-export function initializeInstrumentations(internalLogger: InternalLogger): Instrumentations {
+export function initializeInstrumentations(internalLogger: InternalLogger, _config: Config): Instrumentations {
   internalLogger.debug('Initializing instrumentations');
 
   const instrumentations: Instrumentation[] = [];

--- a/packages/core/src/instrumentations/initialize.ts
+++ b/packages/core/src/instrumentations/initialize.ts
@@ -1,8 +1,7 @@
-import type { Config } from '../config';
 import type { InternalLogger } from '../internalLogger';
 import type { Instrumentation, Instrumentations } from './types';
 
-export function initializeInstrumentations(internalLogger: InternalLogger, config: Config): Instrumentations {
+export function initializeInstrumentations(internalLogger: InternalLogger): Instrumentations {
   internalLogger.debug('Initializing instrumentations');
 
   const instrumentations: Instrumentation[] = [];
@@ -55,8 +54,6 @@ export function initializeInstrumentations(internalLogger: InternalLogger, confi
       instrumentations.splice(existingInstrumentationIndex, 1);
     });
   };
-
-  add(...config.instrumentations);
 
   return {
     add,

--- a/packages/core/src/metas/initialize.test.ts
+++ b/packages/core/src/metas/initialize.test.ts
@@ -1,0 +1,24 @@
+import { mockConfig, mockInternalLogger } from '../testUtils';
+import { initializeMetas } from './initialize';
+
+describe('metas', () => {
+  it('can set listeners and they will be notified on meta changes', () => {
+    const config = mockConfig();
+    const metas = initializeMetas(mockInternalLogger, config);
+    const listener = jest.fn(() => {});
+    metas.addListener(listener);
+
+    metas.add({ user: { id: 'foo' } });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(metas.value);
+
+    metas.add({ session: { id: '1' } });
+    expect(listener).toHaveBeenCalledTimes(2);
+    metas.removeListener(listener);
+
+    metas.add({ session: { id: '2' } });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});
+
+export {};

--- a/packages/core/src/metas/initialize.ts
+++ b/packages/core/src/metas/initialize.ts
@@ -8,16 +8,11 @@ export function initializeMetas(internalLogger: InternalLogger, config: Config):
   let items: MetaItem[] = [];
   let listeners: MetasListener[] = [];
 
-  const _getValue = () => {
-    return items.reduce<Meta>((acc, item) => {
-      Object.assign(acc, isFunction(item) ? item() : item);
-      return acc;
-    }, {});
-  };
+  const getValue = () => items.reduce<Meta>((acc, item) => Object.assign(acc, isFunction(item) ? item() : item), {});
 
-  const _notifyListeners = () => {
+  const notifyListeners = () => {
     if (listeners.length) {
-      const value = _getValue();
+      const value = getValue();
       listeners.forEach((listener) => listener(value));
     }
   };
@@ -25,13 +20,13 @@ export function initializeMetas(internalLogger: InternalLogger, config: Config):
   const add: Metas['add'] = (...newItems) => {
     internalLogger.debug('Adding metas\n', newItems);
     items.push(...newItems);
-    _notifyListeners();
+    notifyListeners();
   };
 
   const remove: Metas['remove'] = (...itemsToRemove) => {
     internalLogger.debug('Removing metas\n', itemsToRemove);
     items = items.filter((currentItem) => !itemsToRemove.includes(currentItem));
-    _notifyListeners();
+    notifyListeners();
   };
 
   const initial: Meta = {
@@ -66,7 +61,7 @@ export function initializeMetas(internalLogger: InternalLogger, config: Config):
     addListener,
     removeListener,
     get value() {
-      return _getValue();
+      return getValue();
     },
   };
 }

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -2,9 +2,12 @@ export type MetaGetter<P = Partial<Meta>> = () => P;
 
 export type MetaItem<P = Partial<Meta>> = P | MetaGetter<P>;
 
+export type MetasListener = (value: Meta) => void;
 export interface Metas {
   add: (...getters: MetaItem[]) => void;
   remove: (...getters: MetaItem[]) => void;
+  addListener: (listener: MetasListener) => void;
+  removeListener: (listener: MetasListener) => void;
   value: Meta;
 }
 
@@ -37,6 +40,7 @@ export interface MetaUser {
 
 export interface MetaSession {
   id?: string;
+  started?: string;
   attributes?: MetaAttributes;
 }
 

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -3,6 +3,7 @@ export type MetaGetter<P = Partial<Meta>> = () => P;
 export type MetaItem<P = Partial<Meta>> = P | MetaGetter<P>;
 
 export type MetasListener = (value: Meta) => void;
+
 export interface Metas {
   add: (...getters: MetaItem[]) => void;
   remove: (...getters: MetaItem[]) => void;

--- a/packages/core/src/semantic.ts
+++ b/packages/core/src/semantic.ts
@@ -1,0 +1,5 @@
+export const Events = {
+  CLICK: 'click',
+  NAVIGATION: 'navigation',
+  SESSION_START: 'session_start',
+} as const;

--- a/packages/core/src/semantic.ts
+++ b/packages/core/src/semantic.ts
@@ -1,5 +1,7 @@
-export const Events = {
-  CLICK: 'click',
-  NAVIGATION: 'navigation',
-  SESSION_START: 'session_start',
+export const Conventions = {
+  EventNames: {
+    CLICK: 'click',
+    NAVIGATION: 'navigation',
+    SESSION_START: 'session_start',
+  },
 } as const;

--- a/packages/core/src/testUtils/mockConfig.ts
+++ b/packages/core/src/testUtils/mockConfig.ts
@@ -11,7 +11,7 @@ export function mockConfig(overrides: Partial<Config> = {}): Config {
     globalObjectKey: 'grafanaAgent',
     internalLoggerLevel: defaultInternalLoggerLevel,
     instrumentations: [],
-    isolate: false,
+    isolate: true,
     metas: [],
     parseStacktrace: mockStacktraceParser,
     paused: false,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -38,3 +38,5 @@ export { noop } from './noop';
 
 export { createPromiseBuffer } from './promiseBuffer';
 export type { BufferItem, PromiseBuffer, PromiseBufferOptions, PromiseProducer } from './promiseBuffer';
+
+export { genShortID } from './shortId';

--- a/packages/core/src/utils/shortId.ts
+++ b/packages/core/src/utils/shortId.ts
@@ -1,0 +1,7 @@
+const alphabet = 'abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ0123456789';
+
+export function genShortID(length = 10): string {
+  return Array.from(Array(length))
+    .map((): string => alphabet[Math.floor(Math.random() * alphabet.length)]!)
+    .join('');
+}

--- a/packages/tracing-web/src/index.ts
+++ b/packages/tracing-web/src/index.ts
@@ -1,5 +1,7 @@
 export { GrafanaAgentTraceExporter } from './agentExporter';
 
+export { SessionSpanProcessor } from './sessionSpanProcessor';
+
 export { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
 
 export { TracingInstrumentation } from './instrumentation';

--- a/packages/tracing-web/src/index.ts
+++ b/packages/tracing-web/src/index.ts
@@ -1,6 +1,6 @@
 export { GrafanaAgentTraceExporter } from './agentExporter';
 
-export { SessionSpanProcessor } from './sessionSpanProcessor';
+export { GrafanaAgentSessionSpanProcessor } from './sessionSpanProcessor';
 
 export { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
 

--- a/packages/tracing-web/src/instrumentation.ts
+++ b/packages/tracing-web/src/instrumentation.ts
@@ -10,6 +10,7 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import { GrafanaAgentTraceExporter } from './agentExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+import { SessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
 
 // the providing of app name here is not great
@@ -47,9 +48,11 @@ export class TracingInstrumentation extends BaseInstrumentation {
 
     provider.addSpanProcessor(
       options.spanProcessor ??
-        new BatchSpanProcessor(new GrafanaAgentTraceExporter({ agent }), {
-          scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
-        })
+        new SessionSpanProcessor(
+          new BatchSpanProcessor(new GrafanaAgentTraceExporter({ agent }), {
+            scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
+          })
+        )
     );
 
     provider.register({

--- a/packages/tracing-web/src/instrumentation.ts
+++ b/packages/tracing-web/src/instrumentation.ts
@@ -10,7 +10,7 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import { GrafanaAgentTraceExporter } from './agentExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
-import { SessionSpanProcessor } from './sessionSpanProcessor';
+import { GrafanaAgentSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
 
 // the providing of app name here is not great
@@ -48,7 +48,7 @@ export class TracingInstrumentation extends BaseInstrumentation {
 
     provider.addSpanProcessor(
       options.spanProcessor ??
-        new SessionSpanProcessor(
+        new GrafanaAgentSessionSpanProcessor(
           new BatchSpanProcessor(new GrafanaAgentTraceExporter({ agent }), {
             scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
           })

--- a/packages/tracing-web/src/sessionSpanProcessor.ts
+++ b/packages/tracing-web/src/sessionSpanProcessor.ts
@@ -16,9 +16,11 @@ export class SessionSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     const session = agent.metas.value.session;
+
     if (session?.id) {
       span.attributes['session_id'] = session.id;
     }
+
     this.processor.onStart(span, parentContext);
   }
 

--- a/packages/tracing-web/src/sessionSpanProcessor.ts
+++ b/packages/tracing-web/src/sessionSpanProcessor.ts
@@ -3,7 +3,7 @@ import type { Context } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 // adds grafana agent session id to every span
-export class SessionSpanProcessor implements SpanProcessor {
+export class GrafanaAgentSessionSpanProcessor implements SpanProcessor {
   private processor: SpanProcessor;
 
   constructor(processor: SpanProcessor) {

--- a/packages/tracing-web/src/sessionSpanProcessor.ts
+++ b/packages/tracing-web/src/sessionSpanProcessor.ts
@@ -16,7 +16,6 @@ export class SessionSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     const session = agent.metas.value.session;
-    console.log('onStart', span, session?.id);
     if (session?.id) {
       span.attributes['session_id'] = session.id;
     }

--- a/packages/tracing-web/src/sessionSpanProcessor.ts
+++ b/packages/tracing-web/src/sessionSpanProcessor.ts
@@ -1,0 +1,33 @@
+import { agent } from '@grafana/agent-core';
+import type { Context } from '@opentelemetry/api';
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+// adds grafana agent session id to every span
+export class SessionSpanProcessor implements SpanProcessor {
+  private processor: SpanProcessor;
+
+  constructor(processor: SpanProcessor) {
+    this.processor = processor;
+  }
+
+  forceFlush(): Promise<void> {
+    return this.processor.forceFlush();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    const session = agent.metas.value.session;
+    console.log('onStart', span, session?.id);
+    if (session?.id) {
+      span.attributes['session_id'] = session.id;
+    }
+    this.processor.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.processor.onEnd(span);
+  }
+
+  shutdown(): Promise<void> {
+    return this.processor.shutdown();
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@grafana/agent-core": "~0.4.0",
+    "short-unique-id": "^4.4.4",
     "ua-parser-js": "^1.0.2",
     "web-vitals": "^2.1.4"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@grafana/agent-core": "~0.4.0",
-    "short-unique-id": "^4.4.4",
     "ua-parser-js": "^1.0.2",
     "web-vitals": "^2.1.4"
   },

--- a/packages/web/src/config/getWebInstrumentations.ts
+++ b/packages/web/src/config/getWebInstrumentations.ts
@@ -1,7 +1,11 @@
 import type { Instrumentation } from '@grafana/agent-core';
 
-import { ConsoleInstrumentation, ErrorsInstrumentation, WebVitalsInstrumentation } from '../instrumentations';
-import { SessionInstrumentation } from '../instrumentations/session/instrumentation';
+import {
+  ConsoleInstrumentation,
+  ErrorsInstrumentation,
+  WebVitalsInstrumentation,
+  SessionInstrumentation,
+} from '../instrumentations';
 import type { GetWebInstrumentationsOptions } from './types';
 
 export function getWebInstrumentations(options: GetWebInstrumentationsOptions = {}): Instrumentation[] {

--- a/packages/web/src/config/getWebInstrumentations.ts
+++ b/packages/web/src/config/getWebInstrumentations.ts
@@ -1,10 +1,15 @@
 import type { Instrumentation } from '@grafana/agent-core';
 
 import { ConsoleInstrumentation, ErrorsInstrumentation, WebVitalsInstrumentation } from '../instrumentations';
+import { SessionInstrumentation } from '../instrumentations/session/instrumentation';
 import type { GetWebInstrumentationsOptions } from './types';
 
 export function getWebInstrumentations(options: GetWebInstrumentationsOptions = {}): Instrumentation[] {
-  const instrumentations: Instrumentation[] = [new ErrorsInstrumentation(), new WebVitalsInstrumentation()];
+  const instrumentations: Instrumentation[] = [
+    new ErrorsInstrumentation(),
+    new WebVitalsInstrumentation(),
+    new SessionInstrumentation(),
+  ];
 
   if (options.captureConsole !== false) {
     instrumentations.push(new ConsoleInstrumentation());

--- a/packages/web/src/config/makeCoreConfig.ts
+++ b/packages/web/src/config/makeCoreConfig.ts
@@ -9,6 +9,7 @@ import type { Config, Transport } from '@grafana/agent-core';
 import { BROWSER_EVENT_DOMAIN } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { defaultMetas } from '../metas';
+import { createSession } from '../session';
 import { FetchTransport } from '../transports';
 import { getWebInstrumentations } from './getWebInstrumentations';
 import type { BrowserConfig } from './types';
@@ -50,7 +51,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
 
     beforeSend: browserConfig.beforeSend,
     ignoreErrors: browserConfig.ignoreErrors,
-    session: browserConfig.session,
+    session: browserConfig.session ?? createSession(),
     user: browserConfig.user,
     eventDomain: browserConfig.eventDomain ?? BROWSER_EVENT_DOMAIN,
   };

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -131,3 +131,5 @@ export type {
 } from '@grafana/agent-core';
 
 export { BROWSER_EVENT_DOMAIN } from './consts';
+
+export { createSession } from './session';

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -25,6 +25,7 @@ export {
   BaseExtension,
   BaseInstrumentation,
   BaseTransport,
+  Conventions,
   createInternalLogger,
   createPromiseBuffer,
   defaultExceptionType,

--- a/packages/web/src/instrumentations/index.ts
+++ b/packages/web/src/instrumentations/index.ts
@@ -1,3 +1,5 @@
+export { SessionInstrumentation } from './session';
+
 export { ConsoleInstrumentation } from './console';
 export type { ConsoleInstrumentationOptions } from './console';
 

--- a/packages/web/src/instrumentations/session/index.ts
+++ b/packages/web/src/instrumentations/session/index.ts
@@ -1,0 +1,1 @@
+export { SessionInstrumentation } from './instrumentation';

--- a/packages/web/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web/src/instrumentations/session/instrumentation.test.ts
@@ -1,0 +1,49 @@
+import { EventEvent, Conventions, initializeGrafanaAgent, TransportItem } from '@grafana/agent-core';
+import { mockConfig, MockTransport } from '@grafana/agent-core/src/testUtils';
+
+import { createSession } from '../../session';
+import { SessionInstrumentation } from './instrumentation';
+
+describe('SessionInstrumentation', () => {
+  it('will send session start event on initialize', () => {
+    const transport = new MockTransport();
+    const session = createSession({ foo: 'bar' });
+    const config = mockConfig({
+      transports: [transport],
+      instrumentations: [new SessionInstrumentation()],
+      session,
+    });
+    initializeGrafanaAgent(config);
+    expect(transport.items).toHaveLength(1);
+    const event = transport.items[0]! as TransportItem<EventEvent>;
+    expect(event.payload.name).toEqual(Conventions.EventNames.SESSION_START);
+    expect(event.meta.session?.attributes).toEqual({ foo: 'bar' });
+    expect(event.meta.session?.id).toEqual(session.id);
+  });
+
+  it('will send session new start event if setSession is called.', () => {
+    const transport = new MockTransport();
+    const session = createSession({ foo: 'bar' });
+    const config = mockConfig({
+      transports: [transport],
+      instrumentations: [new SessionInstrumentation()],
+      session,
+    });
+    const agent = initializeGrafanaAgent(config);
+    expect(transport.items).toHaveLength(1);
+    let event = transport.items[0]! as TransportItem<EventEvent>;
+    expect(event.payload.name).toEqual(Conventions.EventNames.SESSION_START);
+    expect(event.meta.session?.id).toEqual(session.id);
+
+    agent.metas.add({ user: { id: 'foo' } });
+    expect(transport.items).toHaveLength(1);
+
+    const newSession = createSession();
+    agent.api.setSession(newSession);
+    expect(transport.items).toHaveLength(2);
+    event = transport.items[0]! as TransportItem<EventEvent>;
+    expect(event.meta.session?.id).toEqual(session.id);
+  });
+});
+
+export {};

--- a/packages/web/src/instrumentations/session/instrumentation.ts
+++ b/packages/web/src/instrumentations/session/instrumentation.ts
@@ -1,0 +1,27 @@
+import { BaseInstrumentation, Events, Meta, MetaSession } from '@grafana/agent-core';
+import { VERSION } from 'ua-parser-js';
+
+// all this does is send SESSION_START event
+export class SessionInstrumentation extends BaseInstrumentation {
+  readonly name = '@grafana/agent-web:instrumentation-session';
+  readonly version = VERSION;
+
+  // previously notified session, to ensure we don't send session start
+  // event twice for the same session
+  private notifiedSession: MetaSession | undefined;
+
+  private sendSessionStartEvent(meta: Meta): void {
+    const session = meta.session;
+    if (session && session !== this.notifiedSession) {
+      this.notifiedSession = session;
+      // no need to add attributes and session id, they are included as part of meta
+      // automatically
+      this.agent.api.pushEvent(Events.SESSION_START);
+    }
+  }
+
+  initialize() {
+    this.sendSessionStartEvent(this.agent.metas.value);
+    this.agent.metas.addListener(this.sendSessionStartEvent);
+  }
+}

--- a/packages/web/src/instrumentations/session/instrumentation.ts
+++ b/packages/web/src/instrumentations/session/instrumentation.ts
@@ -12,6 +12,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
   private sendSessionStartEvent(meta: Meta): void {
     const session = meta.session;
+
     if (session && session !== this.notifiedSession) {
       this.notifiedSession = session;
       // no need to add attributes and session id, they are included as part of meta

--- a/packages/web/src/instrumentations/session/instrumentation.ts
+++ b/packages/web/src/instrumentations/session/instrumentation.ts
@@ -1,4 +1,4 @@
-import { BaseInstrumentation, Events, Meta, MetaSession } from '@grafana/agent-core';
+import { BaseInstrumentation, Conventions, Meta, MetaSession } from '@grafana/agent-core';
 import { VERSION } from 'ua-parser-js';
 
 // all this does is send SESSION_START event
@@ -16,12 +16,12 @@ export class SessionInstrumentation extends BaseInstrumentation {
       this.notifiedSession = session;
       // no need to add attributes and session id, they are included as part of meta
       // automatically
-      this.agent.api.pushEvent(Events.SESSION_START);
+      this.agent.api.pushEvent(Conventions.EventNames.SESSION_START);
     }
   }
 
   initialize() {
     this.sendSessionStartEvent(this.agent.metas.value);
-    this.agent.metas.addListener(this.sendSessionStartEvent);
+    this.agent.metas.addListener(this.sendSessionStartEvent.bind(this));
   }
 }

--- a/packages/web/src/session.ts
+++ b/packages/web/src/session.ts
@@ -1,11 +1,9 @@
 import type { MetaSession } from '@grafana/agent-core';
-import ShortUniqueId from 'short-unique-id';
-
-const uid = new ShortUniqueId({ length: 10 });
+import { genShortID } from '@grafana/agent-core';
 
 export function createSession(attributes?: MetaSession['attributes']): MetaSession {
   return {
-    id: uid.randomUUID(),
+    id: genShortID(),
     attributes,
   };
 }

--- a/packages/web/src/session.ts
+++ b/packages/web/src/session.ts
@@ -1,0 +1,11 @@
+import type { MetaSession } from '@grafana/agent-core';
+import ShortUniqueId from 'short-unique-id';
+
+const uid = new ShortUniqueId({ length: 10 });
+
+export function createSession(attributes?: MetaSession['attributes']): MetaSession {
+  return {
+    id: uid.randomUUID(),
+    attributes,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,11 +8893,6 @@ shimmer@^1.2.1:
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
-short-unique-id@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/short-unique-id/-/short-unique-id-4.4.4.tgz#a45df68303bbd2dbb5785ed7708e891809c9cb7a"
-  integrity sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,11 +2775,6 @@
   resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
   integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -8897,6 +8892,11 @@ shimmer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
+
+short-unique-id@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/short-unique-id/-/short-unique-id-4.4.4.tgz#a45df68303bbd2dbb5785ed7708e891809c9cb7a"
+  integrity sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
* Web SDK initializes with autogenerated session id
* `Metas` supports adding listener callbacks that are invoked when meta changes. This is to support sending new session start event if session changes. Prior art: Sentry does this in the same way for the same purpose :) 
* `SessionInstrumentation` sends `session_start` event on init and every time new session is added to meta
* `web-tracing` package gains `SessionProcessor` pass-through processor that will add `session_id` attribute to every span, if session is available

Only generating default session id for web, not core. Do not want to assume how sessions might look for other platforms