### PR TITLE
Add build dependencies to allow app container to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine
 
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 make && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3 make build-base && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:16-alpine
 
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
 WORKDIR /usr/app
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine
 
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3 make && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
       - applogs:/usr/app/demo/logs
     ports:
       - '5173:5173'
+      - '24678:24678'
     depends_on:
       - agent
 


### PR DESCRIPTION
Solve the problem where node cannot compile dependencies

```shell
#7 59.22 error /usr/app/node_modules/@parcel/watcher: Command failed.
#7 59.22 Exit code: 1
#7 59.22 Command: node-gyp-build
#7 59.22 Arguments:
#7 59.22 Directory: /usr/app/node_modules/@parcel/watcher
#7 59.22 Output:
#7 59.22 gyp info it worked if it ends with ok
#7 59.22 gyp info using node-gyp@9.1.0
#7 59.22 gyp info using node@16.17.0 | linux | arm64
#7 59.22 gyp ERR! find Python
#7 59.22 gyp ERR! find Python Python is not set from command line or npm configuration
#7 59.22 gyp ERR! find Python Python is not set from environment variable PYTHON
#7 59.22 gyp ERR! find Python checking if "python3" can be used
#7 59.22 gyp ERR! find Python - "python3" is not in PATH or produced an error
#7 59.22 gyp ERR! find Python checking if "python" can be used
#7 59.22 gyp ERR! find Python - "python" is not in PATH or produced an error
#7 59.22 gyp ERR! find Python
#7 59.22 gyp ERR! find Python **********************************************************
#7 59.22 gyp ERR! find Python You need to install the latest version of Python.
#7 59.22 gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
#7 59.22 gyp ERR! find Python you can try one of the following options:
#7 59.22 gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
#7 59.22 gyp ERR! find Python   (accepted by both node-gyp and npm)
#7 59.22 gyp ERR! find Python - Set the environment variable PYTHON
#7 59.22 gyp ERR! find Python - Set the npm configuration variable python:
#7 59.22 gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
#7 59.22 gyp ERR! find Python For more information consult the documentation at:
#7 59.22 gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
#7 59.22 gyp ERR! find Python **********************************************************
#7 59.22 gyp ERR! find Python
#7 59.22 gyp ERR! configure error
#7 59.22 gyp ERR! stack Error: Could not find any Python installation to use
#7 59.22 gyp ERR! stack     at PythonFinder.fail (/usr/app/node_modules/node-gyp/lib/find-python.js:330:47)
#7 59.22 gyp ERR! stack     at PythonFinder.runChecks (/usr/app/node_modules/node-gyp/lib/find-python.js:159:21)
#7 59.22 gyp ERR! stack     at PythonFinder.<anonymous> (/usr/app/node_modules/node-gyp/lib/find-python.js:202:16)
#7 59.22 gyp ERR! stack     at PythonFinder.execFileCallback (/usr/app/node_modules/node-gyp/lib/find-python.js:294:16)
#7 59.22 gyp ERR! stack     at exithandler (node:child_process:408:5)
#7 59.22 gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:420:5)
#7 59.22 gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
#7 59.22 gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
#7 59.22 gyp ERR! stack     at onErrorNT (node:internal/child_process:478:16)
#7 59.22 gyp ERR! stack     at processTicksAndRejections (node:internal/process/task_queues:83:21)
#7 59.22 gyp ERR! System Linux 5.10.104-linuxkit
#7 59.22 gyp ERR! command "/usr/local/bin/node" "/usr/app/node_modules/.bin/node-gyp" "rebuild"
#7 59.22 gyp ERR! cwd /usr/app/node_modules/@parcel/watcher
#7 59.22 gyp ERR! node -v v16.17.0
#7 59.22 gyp ERR! node-gyp -v v9.1.0
#7 59.22 gyp ERR! not ok
```