### PR TITLE
Add backoff for fetch transport upon rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   `SessionInstrumentation` that sends `session_start` event on initialization or when new session
   is set. `SessionProcessor` for OTel that will add `session_id` attribute to every span if available.
 - Added `agent.api.pushEvent` method for capturing RUM events
-- `FetchTransport` will back off after receiving 429 Too Many Requests response. Events will be dropped during backoff period. Backoff period respects `Retry-After` header if present.
+- `FetchTransport` will back off after receiving 429 Too Many Requests response. Events will be dropped during backoff period.
+  Backoff period respects `Retry-After` header if present.
 
 ## 0.4.0 (2022-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `SessionInstrumentation` that sends `session_start` event on initialization or when new session
   is set. `SessionProcessor` for OTel that will add `session_id` attribute to every span if available.
 - Added `agent.api.pushEvent` method for capturing RUM events
+- `FetchTransport` will back off after receiving 429 Too Many Requests response. Events will be dropped during backoff period. Backoff period respects `Retry-After` header if present.
 
 ## 0.4.0 (2022-06-30)
 

--- a/packages/web/src/transports/fetch/transport.test.ts
+++ b/packages/web/src/transports/fetch/transport.test.ts
@@ -55,6 +55,7 @@ describe('FetchTransport', () => {
 
   it('will back off on 429 for default interval if no retry-after header present', async () => {
     let now = Date.now();
+
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
@@ -69,10 +70,13 @@ describe('FetchTransport', () => {
         },
       })
     );
+
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(1);
+
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(1);
+
     now += 1001;
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -80,6 +84,7 @@ describe('FetchTransport', () => {
 
   it('will back off on 429 for default interval if retry-after header present, with delay', async () => {
     let now = Date.now();
+
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
@@ -94,11 +99,14 @@ describe('FetchTransport', () => {
         },
       })
     );
+
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(1);
+
     now += 1001;
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(1);
+
     now += 1001;
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -106,6 +114,7 @@ describe('FetchTransport', () => {
 
   it('will back off on 429 for default interval if retry-after header present, with delay', async () => {
     let now = Date.now();
+
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
@@ -120,11 +129,14 @@ describe('FetchTransport', () => {
         },
       })
     );
+
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(1);
+
     now += 1001;
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(1);
+
     now += 2001;
     await transport.send(item);
     expect(fetch).toHaveBeenCalledTimes(2);

--- a/packages/web/src/transports/fetch/transport.ts
+++ b/packages/web/src/transports/fetch/transport.ts
@@ -5,15 +5,22 @@ import type { FetchTransportOptions } from './types';
 
 const DEFAULT_BUFFER_SIZE = 30;
 const DEFAULT_CONCURRENCY = 5; // chrome supports 10 total, firefox 17
+const DEFAULT_RATE_LIMIT_BACKOFF_MS = 5000;
 
 export class FetchTransport extends BaseTransport {
   readonly name = '@grafana/agent-web:transport-fetch';
   readonly version = VERSION;
 
   promiseBuffer: PromiseBuffer<Response | void>;
+  private reateLimitBackoffMs: number;
+  private getNow: () => number;
+  private disabledUntil: Date = new Date();
 
   constructor(private options: FetchTransportOptions) {
     super();
+
+    this.reateLimitBackoffMs = options.defaultRateLimitBackoffMs ?? DEFAULT_RATE_LIMIT_BACKOFF_MS;
+    this.getNow = options.getNow ?? (() => Date.now());
 
     this.promiseBuffer = createPromiseBuffer({
       size: options.bufferSize ?? DEFAULT_BUFFER_SIZE,
@@ -23,6 +30,11 @@ export class FetchTransport extends BaseTransport {
 
   async send(item: TransportItem): Promise<void> {
     try {
+      if (this.disabledUntil > new Date(this.getNow())) {
+        this.logWarn(`Dropping transport item due to too many requests. Backoff until ${this.disabledUntil}`);
+        return Promise.resolve();
+      }
+
       await this.promiseBuffer.add(() => {
         const body = JSON.stringify(getTransportBody(item));
 
@@ -40,9 +52,17 @@ export class FetchTransport extends BaseTransport {
           body,
           keepalive: true,
           ...(restOfRequestOptions ?? {}),
-        }).catch(() => {
-          this.logError('Failed sending payload to the receiver\n', JSON.parse(body));
-        });
+        })
+          .then((response) => {
+            if (response.status === 429) {
+              this.disabledUntil = this.getRetryAfterDate(response);
+              this.logWarn(`Too many requests, backing off until ${this.disabledUntil}`);
+            }
+            return response;
+          })
+          .catch((err) => {
+            this.logError('Failed sending payload to the receiver\n', JSON.parse(body), err);
+          });
       });
     } catch (err) {
       this.logError(err);
@@ -51,5 +71,21 @@ export class FetchTransport extends BaseTransport {
 
   override getIgnoreUrls(): Array<string | RegExp> {
     return [this.options.url];
+  }
+
+  private getRetryAfterDate(response: Response): Date {
+    const now = this.getNow();
+    const retryAfterHeader = response.headers.get('Retry-After');
+    if (retryAfterHeader) {
+      const delay = Number(retryAfterHeader);
+      if (!isNaN(delay)) {
+        return new Date(delay * 1000 + now);
+      }
+      const date = Date.parse(retryAfterHeader);
+      if (!isNaN(date)) {
+        return new Date(date);
+      }
+    }
+    return new Date(now + this.reateLimitBackoffMs);
   }
 }

--- a/packages/web/src/transports/fetch/transport.ts
+++ b/packages/web/src/transports/fetch/transport.ts
@@ -13,14 +13,14 @@ export class FetchTransport extends BaseTransport {
 
   promiseBuffer: PromiseBuffer<Response | void>;
 
-  private reateLimitBackoffMs: number;
+  private rateLimitBackoffMs: number;
   private getNow: () => number;
   private disabledUntil: Date = new Date();
 
   constructor(private options: FetchTransportOptions) {
     super();
 
-    this.reateLimitBackoffMs = options.defaultRateLimitBackoffMs ?? DEFAULT_RATE_LIMIT_BACKOFF_MS;
+    this.rateLimitBackoffMs = options.defaultRateLimitBackoffMs ?? DEFAULT_RATE_LIMIT_BACKOFF_MS;
     this.getNow = options.getNow ?? (() => Date.now());
 
     this.promiseBuffer = createPromiseBuffer({
@@ -94,6 +94,6 @@ export class FetchTransport extends BaseTransport {
       }
     }
 
-    return new Date(now + this.reateLimitBackoffMs);
+    return new Date(now + this.rateLimitBackoffMs);
   }
 }

--- a/packages/web/src/transports/fetch/types.ts
+++ b/packages/web/src/transports/fetch/types.ts
@@ -6,11 +6,18 @@ export interface FetchTransportOptions {
   // url of the collector endpoint
   url: string;
 
+  // will be added as `x-api-key` header
+  apiKey?: string;
   // how many requests to buffer in total
   bufferSize?: number;
   // how many requests to execute concurrently
   concurrency?: number;
-  // will be added as `x-api-key` header
-  apiKey?: string;
+  // if rate limit response does not include a Retry-After header,
+  // how many milliseconds to back off before attempting a request.
+  // intermediate events will be dropped, not buffered
+  defaultRateLimitBackoffMs?: number;
+  // get current date
+  getNow?: () => number;
+  // addition options for global.Fetch
   requestOptions?: FetchTransportRequestOptions;
 }

--- a/packages/web/src/transports/fetch/types.ts
+++ b/packages/web/src/transports/fetch/types.ts
@@ -16,8 +16,10 @@ export interface FetchTransportOptions {
   // how many milliseconds to back off before attempting a request.
   // intermediate events will be dropped, not buffered
   defaultRateLimitBackoffMs?: number;
-  // get current date
-  getNow?: () => number;
+  // get current date. for mocking purposes in tests
+  getNow?: clockFn;
   // addition options for global.Fetch
   requestOptions?: FetchTransportRequestOptions;
 }
+
+type clockFn = () => number;


### PR DESCRIPTION
This updates `FetchTransport` to drop events for a period after receiving 429 too many requests. The period is taken from `Retry-After` header if present, or 5 seconds default. This should help with spam. 

fixes #45 