### PR TITLE
Remove empty log file to avoid tracking changes of it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 coverage
 cypress/videos
 cypress/screenshots
-demo/logs
+demo/logs/*.log
 demo/stats.html
 demo/vite.config.ts.timestamp-*.mjs
 dist


### PR DESCRIPTION
The empty log file still allowed git to track changes. This removes it while keeping the directory.